### PR TITLE
refactor(app): Fix shutdown

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"os"
 	"time"
 
 	"go.uber.org/fx"
@@ -11,34 +10,62 @@ import (
 	"fuku/internal/config/sentry"
 )
 
+// Root holds the application root context and its cancellation
+//
+//nolint:containedctx // Root is the designated owner of the app-wide context
+type Root struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// NewRoot creates a new application root context
+func NewRoot() *Root {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &Root{ctx: ctx, cancel: cancel}
+}
+
+// Context returns the root context
+func (r *Root) Context() context.Context {
+	return r.ctx
+}
+
+// Cancel cancels the root context
+func (r *Root) Cancel() {
+	r.cancel()
+}
+
 // App represents the main application container
 type App struct {
-	ui     cli.TUI
-	sentry sentry.Sentry
-	done   chan struct{}
+	ui         cli.TUI
+	sentry     sentry.Sentry
+	shutdowner fx.Shutdowner
+	done       chan struct{}
 }
 
 // NewApp creates a new application instance with its dependencies
-func NewApp(ui cli.TUI, s sentry.Sentry) *App {
+func NewApp(ui cli.TUI, sentry sentry.Sentry, shutdowner fx.Shutdowner) *App {
 	return &App{
-		ui:     ui,
-		sentry: s,
-		done:   make(chan struct{}),
+		ui:         ui,
+		sentry:     sentry,
+		shutdowner: shutdowner,
+		done:       make(chan struct{}),
 	}
 }
 
-// Run executes the application
-func (a *App) Run() {
-	exitCode := a.execute()
+// Run executes the application and signals FX to shut down
+func (a *App) Run(ctx context.Context) {
+	exitCode := a.execute(ctx)
 	close(a.done)
 
 	a.sentry.Flush()
 
-	os.Exit(exitCode)
+	//nolint:errcheck // shutdown is best-effort at exit
+	a.shutdowner.Shutdown(fx.ExitCode(exitCode))
 }
 
 // execute runs the CLI and returns exit code - extracted for testing
-func (a *App) execute() int {
+func (a *App) execute(ctx context.Context) int {
 	defer func() {
 		if r := recover(); r != nil {
 			sentry.CurrentHub().Recover(r)
@@ -47,19 +74,22 @@ func (a *App) execute() int {
 		}
 	}()
 
-	exitCode, _ := a.ui.Execute()
+	exitCode, _ := a.ui.Execute(ctx)
 
 	return exitCode
 }
 
 // Register registers the application's lifecycle hooks with fx
-func Register(lifecycle fx.Lifecycle, app *App) {
+func Register(lifecycle fx.Lifecycle, root *Root, app *App) {
 	lifecycle.Append(fx.Hook{
-		OnStart: func(ctx context.Context) error {
-			go app.Run()
+		OnStart: func(_ context.Context) error {
+			go app.Run(root.Context())
+
 			return nil
 		},
 		OnStop: func(ctx context.Context) error {
+			root.Cancel()
+
 			select {
 			case <-app.done:
 				return nil
@@ -68,19 +98,4 @@ func Register(lifecycle fx.Lifecycle, app *App) {
 			}
 		},
 	})
-}
-
-// provideContext creates a background context cancelled on FX shutdown
-func provideContext(lc fx.Lifecycle) context.Context {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	lc.Append(fx.Hook{
-		OnStop: func(_ context.Context) error {
-			cancel()
-
-			return nil
-		},
-	})
-
-	return ctx
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,6 +15,15 @@ import (
 	"fuku/internal/config/sentry"
 )
 
+func Test_NewRoot(t *testing.T) {
+	root := NewRoot()
+
+	assert.NotNil(t, root.Context())
+
+	root.Cancel()
+	assert.ErrorIs(t, root.Context().Err(), context.Canceled)
+}
+
 func Test_NewApp(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -21,7 +31,7 @@ func Test_NewApp(t *testing.T) {
 	mockTUI := cli.NewMockTUI(ctrl)
 	mockSentry := sentry.NewMockSentry(ctrl)
 
-	application := NewApp(mockTUI, mockSentry)
+	application := NewApp(mockTUI, mockSentry, &noopShutdowner{})
 
 	assert.NotNil(t, application)
 	assert.Equal(t, mockTUI, application.ui)
@@ -50,14 +60,14 @@ func Test_execute(t *testing.T) {
 		{
 			name: "Success",
 			before: func() {
-				mockTUI.EXPECT().Execute().Return(0, nil)
+				mockTUI.EXPECT().Execute(gomock.Any()).Return(0, nil)
 			},
 			expectedExitCode: 0,
 		},
 		{
 			name: "Failure",
 			before: func() {
-				mockTUI.EXPECT().Execute().Return(1, errors.New("runner failed"))
+				mockTUI.EXPECT().Execute(gomock.Any()).Return(1, errors.New("runner failed"))
 			},
 			expectedExitCode: 1,
 		},
@@ -67,10 +77,28 @@ func Test_execute(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.before()
 
-			exitCode := app.execute()
+			exitCode := app.execute(t.Context())
 			assert.Equal(t, tt.expectedExitCode, exitCode)
 		})
 	}
+}
+
+func Test_Run_SignalsShutdown(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTUI := cli.NewMockTUI(ctrl)
+	mockTUI.EXPECT().Execute(gomock.Any()).Return(0, nil)
+
+	mockSentry := sentry.NewMockSentry(ctrl)
+	mockSentry.EXPECT().Flush()
+
+	shutdowner := &recordingShutdowner{}
+	app := NewApp(mockTUI, mockSentry, shutdowner)
+
+	app.Run(t.Context())
+
+	assert.True(t, shutdowner.called)
 }
 
 func Test_Register(t *testing.T) {
@@ -79,7 +107,7 @@ func Test_Register(t *testing.T) {
 
 	mockTUI := cli.NewMockTUI(ctrl)
 	mockSentry := sentry.NewMockSentry(ctrl)
-	app := NewApp(mockTUI, mockSentry)
+	app := NewApp(mockTUI, mockSentry, &noopShutdowner{})
 
 	var (
 		registered   bool
@@ -93,21 +121,29 @@ func Test_Register(t *testing.T) {
 		},
 	}
 
-	Register(testLifecycle, app)
+	Register(testLifecycle, NewRoot(), app)
 
 	assert.True(t, registered)
 	assert.NotNil(t, capturedHook.OnStart)
 	assert.NotNil(t, capturedHook.OnStop)
 }
 
-func Test_Register_OnStop_ReturnsWhenDoneClosed(t *testing.T) {
+func Test_Register_OnStop_CancelsContextAndUnblocksApp(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockTUI := cli.NewMockTUI(ctrl)
+	mockTUI.EXPECT().Execute(gomock.Any()).DoAndReturn(func(ctx context.Context) (int, error) {
+		<-ctx.Done()
+
+		return 0, nil
+	})
+
 	mockSentry := sentry.NewMockSentry(ctrl)
-	app := NewApp(mockTUI, mockSentry)
-	close(app.done)
+	mockSentry.EXPECT().Flush()
+
+	root := NewRoot()
+	app := NewApp(mockTUI, mockSentry, &noopShutdowner{})
 
 	var capturedHook fx.Hook
 
@@ -117,20 +153,32 @@ func Test_Register_OnStop_ReturnsWhenDoneClosed(t *testing.T) {
 		},
 	}
 
-	Register(testLifecycle, app)
+	Register(testLifecycle, root, app)
 
-	ctx := context.Background()
-	err := capturedHook.OnStop(ctx)
+	err := capturedHook.OnStart(context.Background())
 	require.NoError(t, err)
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- capturedHook.OnStop(context.Background())
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("OnStop did not return after cancelling root context")
+	}
 }
 
-func Test_Register_OnStop_RespectsContext(t *testing.T) {
+func Test_Register_OnStop_RespectsTimeout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockTUI := cli.NewMockTUI(ctrl)
 	mockSentry := sentry.NewMockSentry(ctrl)
-	app := NewApp(mockTUI, mockSentry)
+	app := NewApp(mockTUI, mockSentry, &noopShutdowner{})
 
 	var capturedHook fx.Hook
 
@@ -140,7 +188,7 @@ func Test_Register_OnStop_RespectsContext(t *testing.T) {
 		},
 	}
 
-	Register(testLifecycle, app)
+	Register(testLifecycle, NewRoot(), app)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -159,4 +207,20 @@ func (t *testLifecycleImpl) Append(hook fx.Hook) {
 	if t.onAppend != nil {
 		t.onAppend(hook)
 	}
+}
+
+// noopShutdowner implements fx.Shutdowner for testing
+type noopShutdowner struct{}
+
+func (n *noopShutdowner) Shutdown(_ ...fx.ShutdownOption) error { return nil }
+
+// recordingShutdowner records Shutdown calls for assertions
+type recordingShutdowner struct {
+	called bool
+}
+
+func (r *recordingShutdowner) Shutdown(_ ...fx.ShutdownOption) error {
+	r.called = true
+
+	return nil
 }

--- a/internal/app/cli/tui.go
+++ b/internal/app/cli/tui.go
@@ -13,7 +13,7 @@ import (
 
 // TUI defines the interface for terminal UI operations
 type TUI interface {
-	Execute() (exitCode int, err error)
+	Execute(ctx context.Context) (exitCode int, err error)
 }
 
 // tui represents the terminal UI for the application
@@ -49,9 +49,7 @@ func NewTUI(
 }
 
 // Execute processes the parsed command and executes the appropriate handler
-func (t *tui) Execute() (int, error) {
-	ctx := context.Background()
-
+func (t *tui) Execute(ctx context.Context) (int, error) {
 	t.bus.Publish(bus.Message{
 		Type: bus.EventCommandStarted,
 		Data: bus.CommandStarted{
@@ -65,7 +63,7 @@ func (t *tui) Execute() (int, error) {
 	case CommandStop:
 		return t.handleStop(ctx, t.cmd.Profile)
 	case CommandLogs:
-		return t.handleLogs()
+		return t.handleLogs(ctx)
 	default:
 		return t.handleRun(ctx, t.cmd.Profile)
 	}
@@ -140,6 +138,6 @@ func (t *tui) runWithUI(ctx context.Context, profile string) (int, error) {
 }
 
 // handleLogs streams logs from a running fuku instance
-func (t *tui) handleLogs() (int, error) {
-	return t.streamer.Run(t.cmd.Profile, t.cmd.Services), nil
+func (t *tui) handleLogs(ctx context.Context) (int, error) {
+	return t.streamer.Run(ctx, t.cmd.Profile, t.cmd.Services), nil
 }

--- a/internal/app/cli/tui_mock.go
+++ b/internal/app/cli/tui_mock.go
@@ -10,6 +10,7 @@
 package cli
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -40,16 +41,16 @@ func (m *MockTUI) EXPECT() *MockTUIMockRecorder {
 }
 
 // Execute mocks base method.
-func (m *MockTUI) Execute() (int, error) {
+func (m *MockTUI) Execute(ctx context.Context) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Execute")
+	ret := m.ctrl.Call(m, "Execute", ctx)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Execute indicates an expected call of Execute.
-func (mr *MockTUIMockRecorder) Execute() *gomock.Call {
+func (mr *MockTUIMockRecorder) Execute(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockTUI)(nil).Execute))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockTUI)(nil).Execute), ctx)
 }

--- a/internal/app/cli/tui_test.go
+++ b/internal/app/cli/tui_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
@@ -154,7 +155,7 @@ func Test_Execute(t *testing.T) {
 
 			tt.before()
 
-			exitCode, err := tu.Execute()
+			exitCode, err := tu.Execute(t.Context())
 
 			w.Close()
 
@@ -219,13 +220,53 @@ func Test_Execute_LogsMode(t *testing.T) {
 				log:      mockLogger,
 			}
 
-			mockLogsScreen.EXPECT().Run(tt.profile, tt.services).Return(0)
+			mockLogsScreen.EXPECT().Run(gomock.Any(), tt.profile, tt.services).Return(0)
 
-			exitCode, err := tu.Execute()
+			exitCode, err := tu.Execute(t.Context())
 
 			assert.Equal(t, 0, exitCode)
 			require.NoError(t, err)
 		})
+	}
+}
+
+func Test_Execute_LogsMode_RespectsContextCancellation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogsScreen := logs.NewMockScreen(ctrl)
+	mockLogger := logger.NewMockLogger(ctrl)
+
+	mockLogsScreen.EXPECT().Run(gomock.Any(), "", []string{"api"}).DoAndReturn(
+		func(ctx context.Context, _ string, _ []string) int {
+			<-ctx.Done()
+
+			return 0
+		},
+	)
+
+	tu := &tui{
+		cmd:      &Options{Type: CommandLogs, Profile: "", Services: []string{"api"}},
+		bus:      bus.NoOp(),
+		streamer: mockLogsScreen,
+		log:      mockLogger,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+
+	go func() {
+		tu.Execute(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Execute did not return after context cancellation")
 	}
 }
 
@@ -333,7 +374,7 @@ func Test_runWithUI_UICreationError(t *testing.T) {
 		},
 	}
 
-	exitCode, err := tu.runWithUI(context.Background(), "test")
+	exitCode, err := tu.runWithUI(t.Context(), "test")
 
 	assert.Equal(t, 1, exitCode)
 	require.Error(t, err)
@@ -371,7 +412,7 @@ func Test_runWithUI_RunnerError(t *testing.T) {
 
 	os.Stdout = w
 
-	exitCode, err := tu.runWithUI(context.Background(), "test")
+	exitCode, err := tu.runWithUI(t.Context(), "test")
 
 	w.Close()
 
@@ -413,7 +454,7 @@ func Test_runWithUI_Success(t *testing.T) {
 		},
 	}
 
-	exitCode, err := tu.runWithUI(context.Background(), "test")
+	exitCode, err := tu.runWithUI(t.Context(), "test")
 
 	inputR.Close()
 

--- a/internal/app/logs/screen.go
+++ b/internal/app/logs/screen.go
@@ -17,7 +17,7 @@ import (
 
 // Screen handles the fuku logs command
 type Screen interface {
-	Run(profile string, services []string) int
+	Run(ctx context.Context, profile string, services []string) int
 }
 
 // screen implements the Screen interface
@@ -53,18 +53,18 @@ func terminalWidth() int {
 }
 
 // Run handles the logs command to stream logs from a running instance
-func (s *screen) Run(profile string, services []string) int {
+func (s *screen) Run(ctx context.Context, profile string, services []string) int {
 	socketPath, err := relay.FindSocket(config.SocketDir, profile)
 	if err != nil {
 		s.log.Error().Err(err).Msg("Failed to find socket")
 		return 1
 	}
 
-	return s.streamLogs(socketPath, services)
+	return s.streamLogs(ctx, socketPath, services)
 }
 
 // streamLogs connects to a running fuku instance and streams logs
-func (s *screen) streamLogs(socketPath string, services []string) int {
+func (s *screen) streamLogs(ctx context.Context, socketPath string, services []string) int {
 	if err := s.client.Connect(socketPath); err != nil {
 		s.log.Error().Err(err).Msg("Failed to connect to socket")
 		return 1
@@ -77,7 +77,7 @@ func (s *screen) streamLogs(socketPath string, services []string) int {
 		return 1
 	}
 
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	handler := &screenHandler{

--- a/internal/app/logs/screen_mock.go
+++ b/internal/app/logs/screen_mock.go
@@ -10,6 +10,7 @@
 package logs
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -40,15 +41,15 @@ func (m *MockScreen) EXPECT() *MockScreenMockRecorder {
 }
 
 // Run mocks base method.
-func (m *MockScreen) Run(profile string, services []string) int {
+func (m *MockScreen) Run(ctx context.Context, profile string, services []string) int {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Run", profile, services)
+	ret := m.ctrl.Call(m, "Run", ctx, profile, services)
 	ret0, _ := ret[0].(int)
 	return ret0
 }
 
 // Run indicates an expected call of Run.
-func (mr *MockScreenMockRecorder) Run(profile, services any) *gomock.Call {
+func (mr *MockScreenMockRecorder) Run(ctx, profile, services any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockScreen)(nil).Run), profile, services)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockScreen)(nil).Run), ctx, profile, services)
 }

--- a/internal/app/logs/screen_test.go
+++ b/internal/app/logs/screen_test.go
@@ -105,7 +105,7 @@ func Test_screen_streamLogs(t *testing.T) {
 				width:  func() int { return 80 },
 			}
 
-			result := s.streamLogs("/tmp/test.sock", tt.services)
+			result := s.streamLogs(t.Context(), "/tmp/test.sock", tt.services)
 
 			assert.Equal(t, tt.expect, result)
 		})
@@ -152,7 +152,7 @@ func Test_screen_streamLogs_WritesToOutput(t *testing.T) {
 		width:  func() int { return 80 },
 	}
 
-	result := s.streamLogs("/tmp/test.sock", []string{"api"})
+	result := s.streamLogs(t.Context(), "/tmp/test.sock", []string{"api"})
 
 	assert.Equal(t, 0, result)
 
@@ -185,7 +185,7 @@ func Test_screen_Run(t *testing.T) {
 			width:  func() int { return 80 },
 		}
 
-		result := s.Run("nonexistent-profile-that-does-not-exist", nil)
+		result := s.Run(t.Context(), "nonexistent-profile-that-does-not-exist", nil)
 
 		assert.Equal(t, 1, result)
 	})
@@ -221,7 +221,7 @@ func Test_screen_Run(t *testing.T) {
 			width:  func() int { return 80 },
 		}
 
-		result := s.Run(profile, []string{"api"})
+		result := s.Run(t.Context(), profile, []string{"api"})
 
 		assert.Equal(t, 0, result)
 	})

--- a/internal/app/module.go
+++ b/internal/app/module.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+
 	"go.uber.org/fx"
 
 	"fuku/internal/app/bus"
@@ -29,7 +31,8 @@ var Module = fx.Options(
 	tracer.Module,
 	watcher.Module,
 	wire.Module,
-	fx.Provide(provideContext),
+	fx.Provide(NewRoot),
+	fx.Provide(func(root *Root) context.Context { return root.Context() }),
 	fx.Provide(NewApp),
 	fx.Invoke(Register),
 )

--- a/internal/app/relay/module.go
+++ b/internal/app/relay/module.go
@@ -31,6 +31,8 @@ func startBridge(lc fx.Lifecycle, ctx context.Context, bridge *Bridge) {
 func startServer(lc fx.Lifecycle, ctx context.Context, server *Server) {
 	lc.Append(fx.Hook{
 		OnStart: func(_ context.Context) error {
+			server.Subscribe(ctx)
+
 			go server.Run(ctx)
 
 			return nil

--- a/internal/app/relay/server.go
+++ b/internal/app/relay/server.go
@@ -25,6 +25,8 @@ type Broadcaster interface {
 // Server manages the Unix socket server for log streaming
 type Server struct {
 	bus         bus.Bus
+	ch          <-chan bus.Message
+	cancelSub   context.CancelFunc
 	cancel      context.CancelFunc
 	socketPath  string
 	profile     string
@@ -55,16 +57,25 @@ func (s *Server) SocketPath() string {
 	return s.socketPath
 }
 
-// Run subscribes to the bus and starts the server when the profile is resolved
-func (s *Server) Run(ctx context.Context) {
-	ch := s.bus.Subscribe(ctx)
+// Subscribe registers the server as a bus subscriber, must be called before Run
+func (s *Server) Subscribe(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	s.ch = s.bus.Subscribe(ctx)
+	s.cancelSub = cancel
+}
 
+// Run waits for the profile resolved event and starts the server
+func (s *Server) Run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			s.cancelSub()
+
 			return
-		case msg, ok := <-ch:
+		case msg, ok := <-s.ch:
 			if !ok {
+				s.cancelSub()
+
 				return
 			}
 
@@ -77,6 +88,7 @@ func (s *Server) Run(ctx context.Context) {
 				continue
 			}
 
+			s.cancelSub()
 			s.activate(ctx, data)
 
 			return

--- a/internal/app/relay/server_test.go
+++ b/internal/app/relay/server_test.go
@@ -64,6 +64,84 @@ func Test_NewServer(t *testing.T) {
 	assert.NotNil(t, s)
 }
 
+func Test_Server_Subscribe(t *testing.T) {
+	cfg := config.DefaultConfig()
+	log := logger.NewLoggerWithOutput(cfg, io.Discard)
+
+	s := NewServer(cfg, bus.NoOp(), log)
+
+	s.Subscribe(t.Context())
+
+	assert.NotNil(t, s.ch)
+	assert.NotNil(t, s.cancelSub)
+}
+
+func Test_Server_Run_ActivatesOnProfileResolved(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Logs.Buffer = 10
+
+	b := bus.NewBus(cfg, nil, nil)
+	defer b.Close()
+
+	log := logger.NewLoggerWithOutput(cfg, io.Discard)
+	s := NewServer(cfg, b, log)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	s.Subscribe(ctx)
+
+	tierServices := []bus.Service{{ID: "test-id", Name: "api"}}
+	b.Publish(bus.Message{
+		Type: bus.EventProfileResolved,
+		Data: bus.ProfileResolved{
+			Profile: "test",
+			Tiers:   []bus.Tier{{Name: "default", Services: tierServices}},
+		},
+	})
+
+	done := make(chan struct{})
+
+	go func() {
+		s.Run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after activation")
+	}
+
+	assert.Equal(t, "test", s.profile)
+
+	cancel()
+	s.Stop()
+}
+
+func Test_Server_Run_ContextCancelled(t *testing.T) {
+	cfg := config.DefaultConfig()
+	log := logger.NewLoggerWithOutput(cfg, io.Discard)
+
+	s := NewServer(cfg, bus.NoOp(), log)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	s.Subscribe(ctx)
+
+	done := make(chan struct{})
+
+	go func() {
+		s.Run(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}
+
 func Test_Server_SocketPath(t *testing.T) {
 	cfg := config.DefaultConfig()
 	log := logger.NewLoggerWithOutput(cfg, io.Discard)


### PR DESCRIPTION
- Add `app.Root` to own the application-wide context
- `Register.OnStop` cancels the root before waiting for completion, preventing deadlocks from FX hook ordering Replace `os.Exit` with `fx.Shutdowner` to ensure `FX OnStop` hooks run on exit