### PR TITLE
feat(ui): Add service filter with vim-style search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,7 @@
 - `internal/app/ui/components/blink_test.go` - Blink animation testing
 - `internal/app/ui/components/layout_test.go` - Layout component testing
 - `internal/app/ui/services/controller_test.go` - Service controller testing
+- `internal/app/ui/services/filter_test.go` - Service filter matching and filtering functions
 - `internal/app/ui/services/helpers_test.go` - Service helper functions testing
 - `internal/app/ui/services/keys_test.go` - Services view key bindings
 - `internal/app/ui/services/loader_test.go` - Loader queue operations

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ pgup/pgdn        Scroll viewport
 home/end         Jump to start/end
 r                Restart selected service
 s                Stop/start selected service
+/                Filter services by name
 q                Quit (stops all services)
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ home/end         Jump to start/end
 r                Restart selected service
 s                Stop/start selected service
 /                Filter services by name
+esc              Clear filter
 q                Quit (stops all services)
 ```
 

--- a/docs/src/data/controls.ts
+++ b/docs/src/data/controls.ts
@@ -10,6 +10,8 @@ export function getKeyboardControls(): KeyboardControl[] {
     { keys: [["Home", "End"]], action: "Jump to first / last service" },
     { keys: [["s"]], action: "Stop or start the selected service" },
     { keys: [["r"]], action: "Restart the selected service" },
+    { keys: [["/"]], action: "Filter services by name" },
+    { keys: [["Esc"]], action: "Clear filter" },
     { keys: [["q"]], action: "Quit and stop all services" },
   ];
 }

--- a/docs/src/pages/features/tui.astro
+++ b/docs/src/pages/features/tui.astro
@@ -110,6 +110,8 @@ const nav = getFeaturesNav(base);
               <span class="help-sep">&bull;</span>
               <span class="help-key">r</span> <span class="help-desc">restart</span>
               <span class="help-sep">&bull;</span>
+              <span class="help-key">/</span> <span class="help-desc">filter</span>
+              <span class="help-sep">&bull;</span>
               <span class="help-key">q</span> <span class="help-desc">quit</span>
             </span>
             <span class="help-right">
@@ -124,6 +126,20 @@ const nav = getFeaturesNav(base);
   <h2>Keyboard Controls</h2>
 
   <KeyboardControls />
+
+  <h2>Service Filter</h2>
+
+  <p>
+    Press <code>/</code> to enter filter mode. Type a query to narrow the service list by name &mdash; matching is case-insensitive and works on partial names.
+  </p>
+
+  <p>
+    While typing, use <code>&uarr;</code>/<code>&darr;</code> arrow keys to navigate filtered results. Press <code>Enter</code> to confirm the filter and switch to full navigation (<code>j</code>/<code>k</code>, <code>s</code>, <code>r</code>). Press <code>Esc</code> to clear the filter and restore the full list.
+  </p>
+
+  <p>
+    The filter bar appears in the bottom border alongside CPU/memory stats. A cursor (<code>_</code>) indicates active input mode.
+  </p>
 
   <h2>Resource Monitoring</h2>
 

--- a/e2e/default_tier_test.go
+++ b/e2e/default_tier_test.go
@@ -58,9 +58,11 @@ func Test_DefaultTier_GracefulShutdown(t *testing.T) {
 
 	output := runner.Output()
 
-	// Shutdown
-	assert.Contains(t, output, "signal signal=terminated")
-	assert.Contains(t, output, "Received signal terminated, shutting down services")
+	// Shutdown outcome
+	assert.Contains(t, output, "phase=stopping")
+	assert.Contains(t, output, "service_stopped")
+	assert.Contains(t, output, "All services stopped")
+	assert.Contains(t, output, "phase=stopped")
 }
 
 func Test_DefaultTier_LogsCommand(t *testing.T) {

--- a/internal/app/ui/services/filter.go
+++ b/internal/app/ui/services/filter.go
@@ -1,0 +1,66 @@
+package services
+
+import "strings"
+
+// normalizeQuery trims leading/trailing dashes, underscores, and spaces, then lowercases
+func normalizeQuery(raw string) string {
+	return strings.ToLower(strings.Trim(raw, "-_ "))
+}
+
+// filterServiceIDs returns the subset of allIDs whose service names match the query, preserving order
+func filterServiceIDs(query string, allIDs []string, services map[string]*ServiceState) []string {
+	q := normalizeQuery(query)
+	if q == "" {
+		return allIDs
+	}
+
+	result := make([]string, 0, len(allIDs))
+
+	for _, id := range allIDs {
+		svc, exists := services[id]
+		if !exists {
+			continue
+		}
+
+		if strings.Contains(strings.ToLower(svc.Name), q) {
+			result = append(result, id)
+		}
+	}
+
+	return result
+}
+
+// filterTiers returns tiers with only matching services, omitting tiers that have no matches
+func filterTiers(query string, tiers []Tier, services map[string]*ServiceState) []Tier {
+	q := normalizeQuery(query)
+	if q == "" {
+		return tiers
+	}
+
+	result := make([]Tier, 0, len(tiers))
+
+	for _, tier := range tiers {
+		matched := make([]string, 0, len(tier.Services))
+
+		for _, id := range tier.Services {
+			svc, exists := services[id]
+			if !exists {
+				continue
+			}
+
+			if strings.Contains(strings.ToLower(svc.Name), q) {
+				matched = append(matched, id)
+			}
+		}
+
+		if len(matched) > 0 {
+			result = append(result, Tier{
+				Name:     tier.Name,
+				Services: matched,
+				Ready:    tier.Ready,
+			})
+		}
+	}
+
+	return result
+}

--- a/internal/app/ui/services/filter_test.go
+++ b/internal/app/ui/services/filter_test.go
@@ -1,0 +1,237 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NormalizeQuery(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "lowercase passthrough",
+			input: "api",
+			want:  "api",
+		},
+		{
+			name:  "uppercase to lowercase",
+			input: "API",
+			want:  "api",
+		},
+		{
+			name:  "mixed case",
+			input: "ApI-Server",
+			want:  "api-server",
+		},
+		{
+			name:  "trim leading dash",
+			input: "-api",
+			want:  "api",
+		},
+		{
+			name:  "trim trailing dash",
+			input: "api-",
+			want:  "api",
+		},
+		{
+			name:  "trim leading underscore",
+			input: "_api",
+			want:  "api",
+		},
+		{
+			name:  "trim trailing underscore",
+			input: "api_",
+			want:  "api",
+		},
+		{
+			name:  "trim leading spaces",
+			input: "  api",
+			want:  "api",
+		},
+		{
+			name:  "trim trailing spaces",
+			input: "api  ",
+			want:  "api",
+		},
+		{
+			name:  "trim mixed separators",
+			input: "- _api_ -",
+			want:  "api",
+		},
+		{
+			name:  "internal separators preserved",
+			input: "api-server_v2",
+			want:  "api-server_v2",
+		},
+		{
+			name:  "only separators",
+			input: "---",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeQuery(tt.input))
+		})
+	}
+}
+
+func Test_FilterServiceIDs(t *testing.T) {
+	services := map[string]*ServiceState{
+		"id-api":    {Name: "api-server"},
+		"id-web":    {Name: "web-app"},
+		"id-db":     {Name: "database"},
+		"id-cache":  {Name: "cache-server"},
+		"id-worker": {Name: "worker"},
+	}
+	allIDs := []string{"id-api", "id-web", "id-db", "id-cache", "id-worker"}
+
+	tests := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{
+			name:  "empty query returns all",
+			query: "",
+			want:  allIDs,
+		},
+		{
+			name:  "match single service",
+			query: "web",
+			want:  []string{"id-web"},
+		},
+		{
+			name:  "match multiple services",
+			query: "server",
+			want:  []string{"id-api", "id-cache"},
+		},
+		{
+			name:  "case insensitive",
+			query: "DATABASE",
+			want:  []string{"id-db"},
+		},
+		{
+			name:  "no matches returns empty",
+			query: "nosuchservice",
+			want:  []string{},
+		},
+		{
+			name:  "preserves order",
+			query: "er",
+			want:  []string{"id-api", "id-cache", "id-worker"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterServiceIDs(tt.query, allIDs, services)
+			if len(tt.want) == 0 {
+				assert.Empty(t, result)
+			} else {
+				assert.Equal(t, tt.want, result)
+			}
+		})
+	}
+}
+
+func Test_FilterTiers(t *testing.T) {
+	services := map[string]*ServiceState{
+		"id-db":     {Name: "database"},
+		"id-cache":  {Name: "cache-server"},
+		"id-api":    {Name: "api-server"},
+		"id-web":    {Name: "web-app"},
+		"id-worker": {Name: "worker"},
+	}
+	tiers := []Tier{
+		{
+			Name:     "foundation",
+			Services: []string{"id-db", "id-cache"},
+			Ready:    true,
+		},
+		{
+			Name:     "application",
+			Services: []string{"id-api", "id-web"},
+			Ready:    false,
+		},
+		{
+			Name:     "background",
+			Services: []string{"id-worker"},
+			Ready:    true,
+		},
+	}
+
+	tests := []struct {
+		name      string
+		query     string
+		wantTiers int
+		assertFn  func(t *testing.T, result []Tier)
+	}{
+		{
+			name:      "empty query returns all tiers",
+			query:     "",
+			wantTiers: 3,
+			assertFn: func(t *testing.T, result []Tier) {
+				assert.Equal(t, tiers, result)
+			},
+		},
+		{
+			name:      "match across tiers",
+			query:     "server",
+			wantTiers: 2,
+			assertFn: func(t *testing.T, result []Tier) {
+				assert.Equal(t, "foundation", result[0].Name)
+				assert.Equal(t, []string{"id-cache"}, result[0].Services)
+				assert.True(t, result[0].Ready)
+				assert.Equal(t, "application", result[1].Name)
+				assert.Equal(t, []string{"id-api"}, result[1].Services)
+				assert.False(t, result[1].Ready)
+			},
+		},
+		{
+			name:      "empty tier omitted",
+			query:     "web",
+			wantTiers: 1,
+			assertFn: func(t *testing.T, result []Tier) {
+				assert.Equal(t, "application", result[0].Name)
+				assert.Equal(t, []string{"id-web"}, result[0].Services)
+			},
+		},
+		{
+			name:      "no matches returns empty",
+			query:     "nosuchservice",
+			wantTiers: 0,
+			assertFn: func(t *testing.T, result []Tier) {
+				assert.Empty(t, result)
+			},
+		},
+		{
+			name:      "single tier match",
+			query:     "worker",
+			wantTiers: 1,
+			assertFn: func(t *testing.T, result []Tier) {
+				assert.Equal(t, "background", result[0].Name)
+				assert.Equal(t, []string{"id-worker"}, result[0].Services)
+				assert.True(t, result[0].Ready)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterTiers(tt.query, tiers, services)
+			assert.Len(t, result, tt.wantTiers)
+			tt.assertFn(t, result)
+		})
+	}
+}

--- a/internal/app/ui/services/keys.go
+++ b/internal/app/ui/services/keys.go
@@ -4,13 +4,15 @@ import "charm.land/bubbles/v2/key"
 
 // KeyMap defines the key bindings for the services view
 type KeyMap struct {
-	Up         key.Binding
-	Down       key.Binding
-	Stop       key.Binding
-	Restart    key.Binding
-	ToggleTips key.Binding
-	Quit       key.Binding
-	ForceQuit  key.Binding
+	Up          key.Binding
+	Down        key.Binding
+	Stop        key.Binding
+	Restart     key.Binding
+	ToggleTips  key.Binding
+	Filter      key.Binding
+	ClearFilter key.Binding
+	Quit        key.Binding
+	ForceQuit   key.Binding
 }
 
 // DefaultKeyMap returns the default key bindings
@@ -36,6 +38,14 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("t"),
 			key.WithHelp("t", "tips"),
 		),
+		Filter: key.NewBinding(
+			key.WithKeys("/"),
+			key.WithHelp("/", "filter"),
+		),
+		ClearFilter: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "clear filter"),
+		),
 		Quit: key.NewBinding(
 			key.WithKeys("q"),
 			key.WithHelp("q", "quit"),
@@ -49,12 +59,12 @@ func DefaultKeyMap() KeyMap {
 
 // ShortHelp returns keybindings to be shown in the mini help view
 func (k KeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Up, k.Down, k.Stop, k.Restart, k.ToggleTips, k.Quit}
+	return []key.Binding{k.Up, k.Down, k.Stop, k.Restart, k.Filter, k.ClearFilter, k.ToggleTips, k.Quit}
 }
 
 // FullHelp returns keybindings for the expanded help view
 func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.Up, k.Down, k.Stop, k.Restart, k.ToggleTips, k.Quit},
+		{k.Up, k.Down, k.Stop, k.Restart, k.Filter, k.ClearFilter, k.ToggleTips, k.Quit},
 	}
 }

--- a/internal/app/ui/services/keys_test.go
+++ b/internal/app/ui/services/keys_test.go
@@ -24,6 +24,8 @@ func Test_DefaultKeyMap(t *testing.T) {
 	assert.Contains(t, km.Stop.Keys(), "s")
 	assert.Contains(t, km.Restart.Keys(), "r")
 	assert.Contains(t, km.ToggleTips.Keys(), "t")
+	assert.Contains(t, km.Filter.Keys(), "/")
+	assert.Contains(t, km.ClearFilter.Keys(), "esc")
 	assert.Contains(t, km.Quit.Keys(), "q")
 	assert.Contains(t, km.ForceQuit.Keys(), "ctrl+c")
 }
@@ -32,13 +34,15 @@ func Test_KeyMap_ShortHelp(t *testing.T) {
 	km := DefaultKeyMap()
 	bindings := km.ShortHelp()
 
-	assert.Len(t, bindings, 6)
+	assert.Len(t, bindings, 8)
 	assert.Equal(t, km.Up, bindings[0])
 	assert.Equal(t, km.Down, bindings[1])
 	assert.Equal(t, km.Stop, bindings[2])
 	assert.Equal(t, km.Restart, bindings[3])
-	assert.Equal(t, km.ToggleTips, bindings[4])
-	assert.Equal(t, km.Quit, bindings[5])
+	assert.Equal(t, km.Filter, bindings[4])
+	assert.Equal(t, km.ClearFilter, bindings[5])
+	assert.Equal(t, km.ToggleTips, bindings[6])
+	assert.Equal(t, km.Quit, bindings[7])
 }
 
 func Test_KeyMap_FullHelp(t *testing.T) {
@@ -46,11 +50,13 @@ func Test_KeyMap_FullHelp(t *testing.T) {
 	bindings := km.FullHelp()
 
 	assert.Len(t, bindings, 1)
-	assert.Len(t, bindings[0], 6)
+	assert.Len(t, bindings[0], 8)
 	assert.Equal(t, km.Up, bindings[0][0])
 	assert.Equal(t, km.Down, bindings[0][1])
 	assert.Equal(t, km.Stop, bindings[0][2])
 	assert.Equal(t, km.Restart, bindings[0][3])
-	assert.Equal(t, km.ToggleTips, bindings[0][4])
-	assert.Equal(t, km.Quit, bindings[0][5])
+	assert.Equal(t, km.Filter, bindings[0][4])
+	assert.Equal(t, km.ClearFilter, bindings[0][5])
+	assert.Equal(t, km.ToggleTips, bindings[0][6])
+	assert.Equal(t, km.Quit, bindings[0][7])
 }

--- a/internal/app/ui/services/model.go
+++ b/internal/app/ui/services/model.go
@@ -96,6 +96,13 @@ type Model struct {
 		appMEM       float64
 		now          time.Time
 		apiStatus    apiHealthStatus
+
+		filterQuery            string
+		filterActive           bool
+		filteredIDs            []string
+		filteredTiers          []Tier
+		preFilterSelectedID    string
+		lastFilteredSelectedID string
 	}
 
 	ui struct {
@@ -184,31 +191,70 @@ func requestBackgroundColorCmd() tea.Msg {
 	return tea.RequestBackgroundColor()
 }
 
+// isFiltering returns true when an effective filter query is applied
+func (m Model) isFiltering() bool {
+	return normalizeQuery(m.state.filterQuery) != ""
+}
+
+// activeServiceIDs returns filteredIDs when filtering, otherwise serviceIDs
+func (m Model) activeServiceIDs() []string {
+	if m.isFiltering() {
+		return m.state.filteredIDs
+	}
+
+	return m.state.serviceIDs
+}
+
 // getSelectedService returns the currently selected service state
 func (m Model) getSelectedService() *ServiceState {
-	if m.state.selected < 0 || m.state.selected >= len(m.state.serviceIDs) {
+	ids := m.activeServiceIDs()
+	if m.state.selected < 0 || m.state.selected >= len(ids) {
 		return nil
 	}
 
-	return m.state.services[m.state.serviceIDs[m.state.selected]]
+	return m.state.services[ids[m.state.selected]]
 }
 
 // getTotalServices returns the total count of services
 func (m Model) getTotalServices() int {
-	return len(m.state.serviceIDs)
+	return len(m.activeServiceIDs())
 }
 
 // getReadyServices returns the count of services in ready state
 func (m Model) getReadyServices() int {
 	count := 0
 
-	for _, service := range m.state.services {
-		if service.Status == StatusRunning {
+	for _, id := range m.activeServiceIDs() {
+		service, exists := m.state.services[id]
+		if exists && service.Status == StatusRunning {
 			count++
 		}
 	}
 
 	return count
+}
+
+// getAllReadyServices returns the count of all services in ready state regardless of filter
+func (m Model) getAllReadyServices() int {
+	count := 0
+
+	for _, id := range m.state.serviceIDs {
+		service, exists := m.state.services[id]
+		if exists && service.Status == StatusRunning {
+			count++
+		}
+	}
+
+	return count
+}
+
+// activeTiers returns filteredTiers when filtering, otherwise tiers
+func (m Model) activeTiers() []Tier {
+	if m.isFiltering() {
+		return m.state.filteredTiers
+	}
+
+	return m.state.tiers
 }
 
 // calculateScrollOffset calculates the scroll offset to ensure the selected service is visible
@@ -220,7 +266,7 @@ func (m Model) calculateScrollOffset() int {
 	lineNumber := 1
 	currentIdx := 0
 
-	for i, tier := range m.state.tiers {
+	for i, tier := range m.activeTiers() {
 		tierStartLine := lineNumber
 
 		if i > 0 {
@@ -261,18 +307,20 @@ func (m Model) calculateScrollOffset() int {
 
 // updateServicesContent builds the full services content and sets it in the viewport
 func (m *Model) updateServicesContent() {
-	if len(m.state.tiers) == 0 {
+	tiers := m.activeTiers()
+
+	if len(tiers) == 0 {
 		m.ui.servicesViewport.SetContent("")
 
 		return
 	}
 
-	sections := make([]string, 0, len(m.state.tiers)+1)
+	sections := make([]string, 0, len(tiers)+1)
 	sections = append(sections, m.renderColumnHeaders())
 
 	currentIdx := 0
 
-	for _, tier := range m.state.tiers {
+	for _, tier := range tiers {
 		sections = append(sections, m.renderTier(tier, &currentIdx))
 	}
 

--- a/internal/app/ui/services/model_test.go
+++ b/internal/app/ui/services/model_test.go
@@ -13,9 +13,11 @@ import (
 
 func Test_GetTotalServices(t *testing.T) {
 	tests := []struct {
-		name       string
-		serviceIDs []string
-		want       int
+		name        string
+		serviceIDs  []string
+		filteredIDs []string
+		filterQuery string
+		want        int
 	}{
 		{
 			name:       "empty",
@@ -32,12 +34,28 @@ func Test_GetTotalServices(t *testing.T) {
 			serviceIDs: []string{"id-api", "id-db", "id-cache"},
 			want:       3,
 		},
+		{
+			name:        "uses filtered IDs when filtering",
+			serviceIDs:  []string{"id-api", "id-db", "id-cache"},
+			filteredIDs: []string{"id-api"},
+			filterQuery: "api",
+			want:        1,
+		},
+		{
+			name:        "empty filter query uses all IDs",
+			serviceIDs:  []string{"id-api", "id-db"},
+			filteredIDs: []string{"id-api"},
+			filterQuery: "",
+			want:        2,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := Model{}
 			m.state.serviceIDs = tt.serviceIDs
+			m.state.filteredIDs = tt.filteredIDs
+			m.state.filterQuery = tt.filterQuery
 			assert.Equal(t, tt.want, m.getTotalServices())
 		})
 	}
@@ -45,37 +63,133 @@ func Test_GetTotalServices(t *testing.T) {
 
 func Test_GetReadyServices(t *testing.T) {
 	tests := []struct {
-		name     string
-		services map[string]*ServiceState
-		want     int
+		name       string
+		serviceIDs []string
+		services   map[string]*ServiceState
+		want       int
 	}{
 		{
-			name:     "empty services",
-			services: map[string]*ServiceState{},
-			want:     0,
+			name:       "empty services",
+			serviceIDs: []string{},
+			services:   map[string]*ServiceState{},
+			want:       0,
 		},
 		{
-			name:     "no ready services",
-			services: map[string]*ServiceState{"id-api": {Status: StatusStarting}, "id-db": {Status: StatusFailed}},
-			want:     0,
+			name:       "no ready services",
+			serviceIDs: []string{"id-api", "id-db"},
+			services:   map[string]*ServiceState{"id-api": {Status: StatusStarting}, "id-db": {Status: StatusFailed}},
+			want:       0,
 		},
 		{
-			name:     "some ready",
-			services: map[string]*ServiceState{"id-api": {Status: StatusRunning}, "id-db": {Status: StatusStarting}},
-			want:     1,
+			name:       "some ready",
+			serviceIDs: []string{"id-api", "id-db"},
+			services:   map[string]*ServiceState{"id-api": {Status: StatusRunning}, "id-db": {Status: StatusStarting}},
+			want:       1,
 		},
 		{
-			name:     "all ready",
-			services: map[string]*ServiceState{"id-api": {Status: StatusRunning}, "id-db": {Status: StatusRunning}},
-			want:     2,
+			name:       "all ready",
+			serviceIDs: []string{"id-api", "id-db"},
+			services:   map[string]*ServiceState{"id-api": {Status: StatusRunning}, "id-db": {Status: StatusRunning}},
+			want:       2,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := Model{}
+			m.state.serviceIDs = tt.serviceIDs
 			m.state.services = tt.services
 			assert.Equal(t, tt.want, m.getReadyServices())
+		})
+	}
+}
+
+func Test_GetAllReadyServices(t *testing.T) {
+	tests := []struct {
+		name        string
+		serviceIDs  []string
+		services    map[string]*ServiceState
+		filterQuery string
+		filteredIDs []string
+		want        int
+	}{
+		{
+			name:       "counts all ready services",
+			serviceIDs: []string{"id-api", "id-db"},
+			services: map[string]*ServiceState{
+				"id-api": {Status: StatusRunning},
+				"id-db":  {Status: StatusRunning},
+			},
+			want: 2,
+		},
+		{
+			name:       "counts only running services",
+			serviceIDs: []string{"id-api", "id-db"},
+			services: map[string]*ServiceState{
+				"id-api": {Status: StatusRunning},
+				"id-db":  {Status: StatusFailed},
+			},
+			want: 1,
+		},
+		{
+			name:        "ignores filter and counts all services",
+			serviceIDs:  []string{"id-api", "id-db", "id-web"},
+			filteredIDs: []string{"id-api"},
+			filterQuery: "api",
+			services: map[string]*ServiceState{
+				"id-api": {Status: StatusRunning},
+				"id-db":  {Status: StatusRunning},
+				"id-web": {Status: StatusFailed},
+			},
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{}
+			m.state.serviceIDs = tt.serviceIDs
+			m.state.services = tt.services
+			m.state.filterQuery = tt.filterQuery
+			m.state.filteredIDs = tt.filteredIDs
+			assert.Equal(t, tt.want, m.getAllReadyServices())
+		})
+	}
+}
+
+func Test_IsFiltering(t *testing.T) {
+	tests := []struct {
+		name        string
+		filterQuery string
+		want        bool
+	}{
+		{
+			name:        "empty query",
+			filterQuery: "",
+			want:        false,
+		},
+		{
+			name:        "non-empty query",
+			filterQuery: "api",
+			want:        true,
+		},
+		{
+			name:        "whitespace only normalizes to empty",
+			filterQuery: " ",
+			want:        false,
+		},
+		{
+			name:        "separator only normalizes to empty",
+			filterQuery: "---",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{}
+			m.state.filterQuery = tt.filterQuery
+			assert.Equal(t, tt.want, m.isFiltering())
 		})
 	}
 }
@@ -89,9 +203,11 @@ func Test_GetSelectedService(t *testing.T) {
 	serviceIDs := []string{"id-db", "id-api", "id-web"}
 
 	tests := []struct {
-		name     string
-		selected int
-		want     string
+		name        string
+		selected    int
+		filterQuery string
+		filteredIDs []string
+		want        string
 	}{
 		{
 			name:     "first service",
@@ -118,6 +234,20 @@ func Test_GetSelectedService(t *testing.T) {
 			selected: 10,
 			want:     "",
 		},
+		{
+			name:        "uses filtered IDs when filtering",
+			selected:    0,
+			filterQuery: "web",
+			filteredIDs: []string{"id-web"},
+			want:        "web",
+		},
+		{
+			name:        "out of bounds in filtered list",
+			selected:    5,
+			filterQuery: "web",
+			filteredIDs: []string{"id-web"},
+			want:        "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -126,6 +256,8 @@ func Test_GetSelectedService(t *testing.T) {
 			m.state.services = services
 			m.state.serviceIDs = serviceIDs
 			m.state.selected = tt.selected
+			m.state.filterQuery = tt.filterQuery
+			m.state.filteredIDs = tt.filteredIDs
 
 			result := m.getSelectedService()
 			if tt.want == "" {

--- a/internal/app/ui/services/update.go
+++ b/internal/app/ui/services/update.go
@@ -131,6 +131,10 @@ func (m Model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	if m.state.filterActive {
+		return m.handleFilterInput(msg)
+	}
+
 	switch {
 	case key.Matches(msg, m.ui.servicesKeys.Quit):
 		m.state.shuttingDown = true
@@ -151,6 +155,16 @@ func (m Model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.ui.servicesKeys.Restart):
 		return m.handleRestartKey()
 
+	case key.Matches(msg, m.ui.servicesKeys.Filter):
+		return m.handleFilterKey()
+
+	case key.Matches(msg, m.ui.servicesKeys.ClearFilter):
+		if m.state.filterQuery != "" {
+			m.clearFilter()
+
+			return m, nil
+		}
+
 	case key.Matches(msg, m.ui.servicesKeys.ToggleTips):
 		m.ui.showTips = !m.ui.showTips
 		return m, nil
@@ -166,6 +180,135 @@ func (m Model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+// handleFilterKey enters filter input mode
+func (m Model) handleFilterKey() (tea.Model, tea.Cmd) {
+	m.state.filterActive = true
+
+	ids := m.activeServiceIDs()
+	if m.state.selected >= 0 && m.state.selected < len(ids) {
+		m.state.preFilterSelectedID = ids[m.state.selected]
+	}
+
+	return m, nil
+}
+
+// clearFilter exits filter mode, restores the full list, and preserves selection on the same service
+func (m *Model) clearFilter() {
+	var previousID string
+
+	if m.state.filteredIDs != nil && m.state.selected >= 0 && m.state.selected < len(m.state.filteredIDs) {
+		previousID = m.state.filteredIDs[m.state.selected]
+	}
+
+	if previousID == "" && m.state.filteredIDs == nil && m.state.selected >= 0 && m.state.selected < len(m.state.serviceIDs) {
+		previousID = m.state.serviceIDs[m.state.selected]
+	}
+
+	if previousID == "" {
+		previousID = m.state.lastFilteredSelectedID
+	}
+
+	if previousID == "" {
+		previousID = m.state.preFilterSelectedID
+	}
+
+	m.state.filterActive = false
+	m.state.filterQuery = ""
+	m.state.filteredIDs = nil
+	m.state.filteredTiers = nil
+	m.state.preFilterSelectedID = ""
+	m.state.lastFilteredSelectedID = ""
+
+	m.state.selected = 0
+
+	for i, id := range m.state.serviceIDs {
+		if id == previousID {
+			m.state.selected = i
+
+			break
+		}
+	}
+
+	m.updateServicesContent()
+	m.ui.servicesViewport.SetYOffset(m.calculateScrollOffset())
+}
+
+// handleFilterInput processes key events while in filter input mode
+func (m Model) handleFilterInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.Code {
+	case tea.KeyEscape:
+		m.clearFilter()
+
+		return m, nil
+
+	case tea.KeyEnter:
+		m.state.filterActive = false
+
+		return m, nil
+
+	case tea.KeyBackspace:
+		if len(m.state.filterQuery) > 0 {
+			runes := []rune(m.state.filterQuery)
+			m.state.filterQuery = string(runes[:len(runes)-1])
+			m.applyFilter()
+		}
+
+		return m, nil
+
+	case tea.KeyUp:
+		return m.handleUpKey()
+
+	case tea.KeyDown:
+		return m.handleDownKey()
+
+	default:
+		if msg.Text != "" {
+			m.state.filterQuery += msg.Text
+			m.applyFilter()
+		}
+
+		return m, nil
+	}
+}
+
+// applyFilter recomputes filteredIDs and filteredTiers from the current query and adjusts selection
+func (m *Model) applyFilter() {
+	var previousID string
+
+	ids := m.state.filteredIDs
+	if ids == nil {
+		ids = m.state.serviceIDs
+	}
+
+	if m.state.selected >= 0 && m.state.selected < len(ids) {
+		previousID = ids[m.state.selected]
+	}
+
+	if previousID == "" {
+		previousID = m.state.lastFilteredSelectedID
+	}
+
+	m.state.filteredIDs = filterServiceIDs(m.state.filterQuery, m.state.serviceIDs, m.state.services)
+	m.state.filteredTiers = filterTiers(m.state.filterQuery, m.state.tiers, m.state.services)
+
+	m.state.selected = 0
+
+	for i, id := range m.state.filteredIDs {
+		if id == previousID {
+			m.state.selected = i
+
+			break
+		}
+	}
+
+	if previousID != "" {
+		m.state.lastFilteredSelectedID = previousID
+	}
+
+	m.updateServicesContent()
+	m.ui.servicesViewport.SetYOffset(m.calculateScrollOffset())
 }
 
 // handleUpKey moves selection up one service
@@ -289,6 +432,12 @@ func (m Model) handleProfileResolved(msg bus.Message) Model {
 	m.state.restarting = make(map[string]bool)
 	m.state.serviceIDs = nil
 	m.state.selected = 0
+	m.state.filterQuery = ""
+	m.state.filterActive = false
+	m.state.filteredIDs = nil
+	m.state.filteredTiers = nil
+	m.state.preFilterSelectedID = ""
+	m.state.lastFilteredSelectedID = ""
 	m.loader.StopAll()
 
 	m.state.tiers = make([]Tier, len(data.Tiers))

--- a/internal/app/ui/services/update_test.go
+++ b/internal/app/ui/services/update_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"charm.land/bubbles/v2/spinner"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -159,6 +160,41 @@ func Test_HandleProfileResolved_ResetsSelection(t *testing.T) {
 
 	result := m.handleProfileResolved(event)
 	assert.Equal(t, 0, result.state.selected, "Selection should reset to 0 on profile reload")
+}
+
+func Test_HandleProfileResolved_ClearsFilterState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLog := logger.NewMockLogger(ctrl)
+	noopLogger := zerolog.New(io.Discard)
+	mockLog.EXPECT().Debug().Return(noopLogger.Debug()).AnyTimes()
+	mockLog.EXPECT().Info().Return(noopLogger.Info()).AnyTimes()
+	mockLog.EXPECT().Warn().Return(noopLogger.Warn()).AnyTimes()
+	mockLog.EXPECT().Error().Return(noopLogger.Error()).AnyTimes()
+
+	m := Model{log: mockLog, loader: NewLoader()}
+	m.state.services = make(map[string]*ServiceState)
+	m.state.restarting = make(map[string]bool)
+	m.state.tiers = make([]Tier, 0)
+	m.state.filterQuery = "db"
+	m.state.filterActive = true
+	m.state.filteredIDs = []string{"id-db"}
+	m.state.filteredTiers = []Tier{{Name: "tier1", Services: []string{"id-db"}}}
+
+	event := bus.Message{
+		Type: bus.EventProfileResolved,
+		Data: bus.ProfileResolved{
+			Profile: "dev",
+			Tiers:   []bus.Tier{{Name: "tier1", Services: []bus.Service{{ID: "test-id-db", Name: "db"}}}},
+		},
+	}
+
+	result := m.handleProfileResolved(event)
+	assert.Empty(t, result.state.filterQuery)
+	assert.False(t, result.state.filterActive)
+	assert.Nil(t, result.state.filteredIDs)
+	assert.Nil(t, result.state.filteredTiers)
 }
 
 func Test_HandleProfileResolved_PreservesReadyState(t *testing.T) {
@@ -970,6 +1006,810 @@ func Test_HandleSignal(t *testing.T) {
 	assert.True(t, result.state.shuttingDown)
 	assert.True(t, result.loader.Active)
 	assert.Equal(t, "shutting down all services\u2026", result.loader.Message())
+}
+
+func Test_HandleFilterKey(t *testing.T) {
+	m := Model{}
+	m.state.filterActive = false
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+		"id-db":  {ID: "id-db", Name: "db"},
+	}
+	m.state.selected = 2
+	m.ui.servicesKeys = DefaultKeyMap()
+
+	teaModel, cmd := m.handleFilterKey()
+	result := teaModel.(Model)
+
+	assert.True(t, result.state.filterActive)
+	assert.Equal(t, "id-db", result.state.preFilterSelectedID)
+	assert.Nil(t, cmd)
+}
+
+func Test_HandleKeyPress_SlashEntersFilterMode(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockController := NewMockController(ctrl)
+	loader := &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}
+
+	m := Model{loader: loader, controller: mockController}
+	m.state.shuttingDown = false
+	m.ui.servicesKeys = DefaultKeyMap()
+
+	msg := toKeyMsg("/")
+	teaModel, cmd := m.handleKeyPress(msg)
+	result := teaModel.(Model)
+
+	assert.True(t, result.state.filterActive)
+	assert.Nil(t, cmd)
+}
+
+func Test_HandleFilterInput(t *testing.T) {
+	tests := []struct {
+		name           string
+		initialQuery   string
+		initialActive  bool
+		msg            tea.KeyPressMsg
+		expectedQuery  string
+		expectedActive bool
+	}{
+		{
+			name:           "Typing appends to query",
+			initialQuery:   "ap",
+			initialActive:  true,
+			msg:            toKeyMsg("i"),
+			expectedQuery:  "api",
+			expectedActive: true,
+		},
+		{
+			name:           "Typing first character",
+			initialQuery:   "",
+			initialActive:  true,
+			msg:            toKeyMsg("a"),
+			expectedQuery:  "a",
+			expectedActive: true,
+		},
+		{
+			name:           "Backspace removes last character",
+			initialQuery:   "api",
+			initialActive:  true,
+			msg:            tea.KeyPressMsg{Code: tea.KeyBackspace},
+			expectedQuery:  "ap",
+			expectedActive: true,
+		},
+		{
+			name:           "Backspace on empty query is no-op",
+			initialQuery:   "",
+			initialActive:  true,
+			msg:            tea.KeyPressMsg{Code: tea.KeyBackspace},
+			expectedQuery:  "",
+			expectedActive: true,
+		},
+		{
+			name:           "Enter exits input mode keeping filter",
+			initialQuery:   "api",
+			initialActive:  true,
+			msg:            tea.KeyPressMsg{Code: tea.KeyEnter},
+			expectedQuery:  "api",
+			expectedActive: false,
+		},
+		{
+			name:           "Escape clears filter and exits input mode",
+			initialQuery:   "api",
+			initialActive:  true,
+			msg:            tea.KeyPressMsg{Code: tea.KeyEscape},
+			expectedQuery:  "",
+			expectedActive: false,
+		},
+		{
+			name:           "Arrow up does not modify query",
+			initialQuery:   "api",
+			initialActive:  true,
+			msg:            tea.KeyPressMsg{Code: tea.KeyUp},
+			expectedQuery:  "api",
+			expectedActive: true,
+		},
+		{
+			name:           "Arrow down does not modify query",
+			initialQuery:   "api",
+			initialActive:  true,
+			msg:            tea.KeyPressMsg{Code: tea.KeyDown},
+			expectedQuery:  "api",
+			expectedActive: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{}
+			m.state.filterQuery = tt.initialQuery
+			m.state.filterActive = tt.initialActive
+			m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+			m.state.services = map[string]*ServiceState{
+				"id-api": {ID: "id-api", Name: "api"},
+				"id-web": {ID: "id-web", Name: "web"},
+				"id-db":  {ID: "id-db", Name: "db"},
+			}
+			m.state.tiers = []Tier{
+				{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+			}
+
+			teaModel, _ := m.handleFilterInput(tt.msg)
+			result := teaModel.(Model)
+
+			assert.Equal(t, tt.expectedQuery, result.state.filterQuery)
+			assert.Equal(t, tt.expectedActive, result.state.filterActive)
+		})
+	}
+}
+
+func Test_HandleKeyPress_FilterActiveRoutesToFilterInput(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockController := NewMockController(ctrl)
+	loader := &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}
+
+	m := Model{loader: loader, controller: mockController}
+	m.state.filterActive = true
+	m.state.filterQuery = ""
+	m.state.serviceIDs = []string{"id-api"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api"}},
+	}
+	m.ui.servicesKeys = DefaultKeyMap()
+
+	msg := toKeyMsg("a")
+	teaModel, _ := m.handleKeyPress(msg)
+	result := teaModel.(Model)
+
+	assert.Equal(t, "a", result.state.filterQuery)
+	assert.True(t, result.state.filterActive)
+}
+
+func Test_ApplyFilter_SelectionAdjustment(t *testing.T) {
+	tests := []struct {
+		name             string
+		serviceIDs       []string
+		services         map[string]*ServiceState
+		tiers            []Tier
+		filterQuery      string
+		initialSelected  int
+		expectedSelected int
+	}{
+		{
+			name:       "Keeps selection when current service still visible",
+			serviceIDs: []string{"id-api", "id-web", "id-db"},
+			services: map[string]*ServiceState{
+				"id-api": {ID: "id-api", Name: "api-server"},
+				"id-web": {ID: "id-web", Name: "web-app"},
+				"id-db":  {ID: "id-db", Name: "db-primary"},
+			},
+			tiers: []Tier{
+				{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+			},
+			filterQuery:      "api",
+			initialSelected:  0,
+			expectedSelected: 0,
+		},
+		{
+			name:       "Moves to first match when current service hidden",
+			serviceIDs: []string{"id-api", "id-web", "id-db"},
+			services: map[string]*ServiceState{
+				"id-api": {ID: "id-api", Name: "api-server"},
+				"id-web": {ID: "id-web", Name: "web-app"},
+				"id-db":  {ID: "id-db", Name: "db-primary"},
+			},
+			tiers: []Tier{
+				{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+			},
+			filterQuery:      "web",
+			initialSelected:  2,
+			expectedSelected: 0,
+		},
+		{
+			name:       "Preserves selection at non-zero filtered position",
+			serviceIDs: []string{"id-api", "id-web", "id-db"},
+			services: map[string]*ServiceState{
+				"id-api": {ID: "id-api", Name: "api-server"},
+				"id-web": {ID: "id-web", Name: "web-app"},
+				"id-db":  {ID: "id-db", Name: "db-primary"},
+			},
+			tiers: []Tier{
+				{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+			},
+			filterQuery:      "p",
+			initialSelected:  1,
+			expectedSelected: 1,
+		},
+		{
+			name:       "Resets to zero on no matches",
+			serviceIDs: []string{"id-api", "id-web", "id-db"},
+			services: map[string]*ServiceState{
+				"id-api": {ID: "id-api", Name: "api-server"},
+				"id-web": {ID: "id-web", Name: "web-app"},
+				"id-db":  {ID: "id-db", Name: "db-primary"},
+			},
+			tiers: []Tier{
+				{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+			},
+			filterQuery:      "zzz",
+			initialSelected:  2,
+			expectedSelected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{}
+			m.state.serviceIDs = tt.serviceIDs
+			m.state.services = tt.services
+			m.state.tiers = tt.tiers
+			m.state.filterQuery = tt.filterQuery
+			m.state.selected = tt.initialSelected
+
+			m.applyFilter()
+
+			assert.Equal(t, tt.expectedSelected, m.state.selected)
+		})
+	}
+}
+
+func Test_HandleFilterInput_ArrowDownNavigates(t *testing.T) {
+	m := Model{}
+	m.state.filterActive = true
+	m.state.filterQuery = "b"
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+		"id-db":  {ID: "id-db", Name: "db"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+	}
+	m.state.filteredIDs = []string{"id-web", "id-db"}
+	m.state.filteredTiers = []Tier{
+		{Name: "tier1", Services: []string{"id-web", "id-db"}},
+	}
+	m.state.selected = 0
+
+	msg := tea.KeyPressMsg{Code: tea.KeyDown}
+	teaModel, _ := m.handleFilterInput(msg)
+	result := teaModel.(Model)
+
+	assert.Equal(t, 1, result.state.selected)
+	assert.Equal(t, "b", result.state.filterQuery)
+	assert.True(t, result.state.filterActive)
+}
+
+func Test_HandleFilterInput_ArrowUpNavigates(t *testing.T) {
+	m := Model{}
+	m.state.filterActive = true
+	m.state.filterQuery = "b"
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+		"id-db":  {ID: "id-db", Name: "db"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+	}
+	m.state.filteredIDs = []string{"id-web", "id-db"}
+	m.state.filteredTiers = []Tier{
+		{Name: "tier1", Services: []string{"id-web", "id-db"}},
+	}
+	m.state.selected = 1
+
+	msg := tea.KeyPressMsg{Code: tea.KeyUp}
+	teaModel, _ := m.handleFilterInput(msg)
+	result := teaModel.(Model)
+
+	assert.Equal(t, 0, result.state.selected)
+	assert.Equal(t, "b", result.state.filterQuery)
+	assert.True(t, result.state.filterActive)
+}
+
+func Test_ApplyFilter_RestoresSelectionAfterTemporaryZeroMatches(t *testing.T) {
+	m := Model{}
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+		"id-db":  {ID: "id-db", Name: "db"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+	}
+
+	m.state.filteredIDs = []string{"id-web", "id-db"}
+	m.state.filteredTiers = []Tier{
+		{Name: "tier1", Services: []string{"id-web", "id-db"}},
+	}
+	m.state.selected = 1
+	m.state.filterQuery = "bx"
+	m.applyFilter()
+
+	assert.Empty(t, m.state.filteredIDs)
+	assert.Equal(t, "id-db", m.state.lastFilteredSelectedID)
+
+	m.state.filterQuery = "b"
+	m.applyFilter()
+
+	assert.Equal(t, []string{"id-web", "id-db"}, m.state.filteredIDs)
+	assert.Equal(t, 1, m.state.selected)
+
+	svc := m.state.services[m.state.filteredIDs[m.state.selected]]
+	assert.Equal(t, "db", svc.Name)
+}
+
+func Test_ApplyFilter_TracksSelectionOnZeroMatches(t *testing.T) {
+	m := Model{}
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+		"id-db":  {ID: "id-db", Name: "db"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+	}
+	m.state.filteredIDs = []string{"id-web", "id-db"}
+	m.state.filteredTiers = []Tier{
+		{Name: "tier1", Services: []string{"id-web", "id-db"}},
+	}
+	m.state.selected = 1
+	m.state.filterQuery = "zzz"
+
+	m.applyFilter()
+
+	assert.Empty(t, m.state.filteredIDs)
+	assert.Equal(t, "id-db", m.state.lastFilteredSelectedID)
+}
+
+func Test_HandleFilterInput_EscapeRestoresLastMatchNotPreFilter(t *testing.T) {
+	m := Model{}
+	m.state.filterActive = true
+	m.state.filterQuery = "zzz"
+	m.state.selected = 0
+	m.state.filteredIDs = []string{}
+	m.state.filteredTiers = []Tier{}
+	m.state.preFilterSelectedID = "id-api"
+	m.state.lastFilteredSelectedID = "id-web"
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+		"id-db":  {ID: "id-db", Name: "db"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+	}
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEscape}
+	teaModel, _ := m.handleFilterInput(msg)
+	result := teaModel.(Model)
+
+	assert.Equal(t, 1, result.state.selected)
+	assert.Empty(t, result.state.lastFilteredSelectedID)
+}
+
+func Test_HandleFilterInput_EscapeClearsFilteredState(t *testing.T) {
+	m := Model{}
+	m.state.filterActive = true
+	m.state.filterQuery = "api"
+	m.state.selected = 0
+	m.state.filteredIDs = []string{"id-api"}
+	m.state.filteredTiers = []Tier{{Name: "tier1", Services: []string{"id-api"}}}
+	m.state.serviceIDs = []string{"id-api", "id-web"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api", "id-web"}},
+	}
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEscape}
+	teaModel, _ := m.handleFilterInput(msg)
+	result := teaModel.(Model)
+
+	assert.Empty(t, result.state.filterQuery)
+	assert.False(t, result.state.filterActive)
+	assert.Nil(t, result.state.filteredIDs)
+	assert.Nil(t, result.state.filteredTiers)
+	assert.Equal(t, 0, result.state.selected)
+}
+
+func Test_HandleFilterInput_EscapeRestoresSelectionPosition(t *testing.T) {
+	m := Model{}
+	m.state.filterActive = true
+	m.state.filterQuery = "web"
+	m.state.selected = 0
+	m.state.filteredIDs = []string{"id-web"}
+	m.state.filteredTiers = []Tier{{Name: "tier1", Services: []string{"id-web"}}}
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+		"id-db":  {ID: "id-db", Name: "db"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+	}
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEscape}
+	teaModel, _ := m.handleFilterInput(msg)
+	result := teaModel.(Model)
+
+	assert.Equal(t, 1, result.state.selected)
+}
+
+func Test_HandleFilterInput_EscapePreservesSelectionWithNoQuery(t *testing.T) {
+	m := Model{}
+	m.state.filterActive = true
+	m.state.filterQuery = ""
+	m.state.selected = 2
+	m.state.preFilterSelectedID = "id-api"
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+		"id-db":  {ID: "id-db", Name: "db"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+	}
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEscape}
+	teaModel, _ := m.handleFilterInput(msg)
+	result := teaModel.(Model)
+
+	assert.Equal(t, 2, result.state.selected)
+	assert.Empty(t, result.state.filterQuery)
+	assert.False(t, result.state.filterActive)
+}
+
+func Test_HandleFilterInput_EscapeRestoresSelectionAfterZeroMatches(t *testing.T) {
+	m := Model{}
+	m.state.filterActive = true
+	m.state.filterQuery = "zzz"
+	m.state.selected = 0
+	m.state.filteredIDs = []string{}
+	m.state.filteredTiers = []Tier{}
+	m.state.preFilterSelectedID = "id-db"
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+		"id-db":  {ID: "id-db", Name: "db"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+	}
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEscape}
+	teaModel, _ := m.handleFilterInput(msg)
+	result := teaModel.(Model)
+
+	assert.Equal(t, 2, result.state.selected)
+	assert.Empty(t, result.state.preFilterSelectedID)
+}
+
+func Test_HandleKeyPress_EscClearsFilterAfterEnter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockController := NewMockController(ctrl)
+	loader := &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}
+
+	m := Model{loader: loader, controller: mockController}
+	m.state.filterActive = false
+	m.state.filterQuery = "web"
+	m.state.filteredIDs = []string{"id-web"}
+	m.state.filteredTiers = []Tier{{Name: "tier1", Services: []string{"id-web"}}}
+	m.state.serviceIDs = []string{"id-api", "id-web"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api", "id-web"}},
+	}
+	m.ui.servicesKeys = DefaultKeyMap()
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEscape}
+	teaModel, _ := m.handleKeyPress(msg)
+	result := teaModel.(Model)
+
+	assert.Empty(t, result.state.filterQuery)
+	assert.False(t, result.state.filterActive)
+	assert.Nil(t, result.state.filteredIDs)
+	assert.Nil(t, result.state.filteredTiers)
+}
+
+func Test_HandleKeyPress_EscClearsSeparatorOnlyQuery(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockController := NewMockController(ctrl)
+	loader := &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}
+
+	m := Model{loader: loader, controller: mockController}
+	m.state.filterActive = false
+	m.state.filterQuery = "---"
+	m.state.filteredIDs = []string{"id-api"}
+	m.state.filteredTiers = []Tier{{Name: "tier1", Services: []string{"id-api"}}}
+	m.state.serviceIDs = []string{"id-api", "id-web"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api", "id-web"}},
+	}
+	m.ui.servicesKeys = DefaultKeyMap()
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEscape}
+	teaModel, _ := m.handleKeyPress(msg)
+	result := teaModel.(Model)
+
+	assert.Empty(t, result.state.filterQuery)
+	assert.False(t, result.state.filterActive)
+	assert.Nil(t, result.state.filteredIDs)
+	assert.Nil(t, result.state.filteredTiers)
+}
+
+func Test_HandleUpKey_WithFilter(t *testing.T) {
+	m := Model{}
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+		"id-db":  {ID: "id-db", Name: "db"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+	}
+	m.state.filterQuery = "b"
+	m.state.filteredIDs = []string{"id-web", "id-db"}
+	m.state.filteredTiers = []Tier{
+		{Name: "tier1", Services: []string{"id-web", "id-db"}},
+	}
+	m.state.selected = 1
+
+	teaModel, _ := m.handleUpKey()
+	result := teaModel.(Model)
+
+	assert.Equal(t, 0, result.state.selected)
+}
+
+func Test_HandleUpKey_WithFilter_AtTop(t *testing.T) {
+	m := Model{}
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+		"id-db":  {ID: "id-db", Name: "db"},
+	}
+	m.state.filterQuery = "api"
+	m.state.filteredIDs = []string{"id-api"}
+	m.state.filteredTiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api"}},
+	}
+	m.state.selected = 0
+
+	teaModel, _ := m.handleUpKey()
+	result := teaModel.(Model)
+
+	assert.Equal(t, 0, result.state.selected)
+}
+
+func Test_HandleDownKey_WithFilter(t *testing.T) {
+	m := Model{}
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+		"id-db":  {ID: "id-db", Name: "db"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api", "id-web", "id-db"}},
+	}
+	m.state.filterQuery = "b"
+	m.state.filteredIDs = []string{"id-web", "id-db"}
+	m.state.filteredTiers = []Tier{
+		{Name: "tier1", Services: []string{"id-web", "id-db"}},
+	}
+	m.state.selected = 0
+
+	teaModel, _ := m.handleDownKey()
+	result := teaModel.(Model)
+
+	assert.Equal(t, 1, result.state.selected)
+}
+
+func Test_HandleDownKey_WithFilter_AtBottom(t *testing.T) {
+	m := Model{}
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+		"id-db":  {ID: "id-db", Name: "db"},
+	}
+	m.state.filterQuery = "api"
+	m.state.filteredIDs = []string{"id-api"}
+	m.state.filteredTiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api"}},
+	}
+	m.state.selected = 0
+
+	teaModel, _ := m.handleDownKey()
+	result := teaModel.(Model)
+
+	assert.Equal(t, 0, result.state.selected)
+}
+
+func Test_HandleDownKey_WithFilter_ZeroMatches(t *testing.T) {
+	m := Model{}
+	m.state.serviceIDs = []string{"id-api", "id-web"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api"},
+		"id-web": {ID: "id-web", Name: "web"},
+	}
+	m.state.filterQuery = "xyz"
+	m.state.filteredIDs = []string{}
+	m.state.filteredTiers = []Tier{}
+	m.state.selected = 0
+
+	teaModel, _ := m.handleDownKey()
+	result := teaModel.(Model)
+
+	assert.Equal(t, 0, result.state.selected)
+}
+
+func Test_HandleStopKey_WithFilter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockController := NewMockController(ctrl)
+	mockController.EXPECT().Stop(bus.Service{ID: "id-web", Name: "web"})
+
+	loader := &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}
+
+	m := Model{loader: loader, controller: mockController}
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api", Status: StatusRunning},
+		"id-web": {ID: "id-web", Name: "web", Status: StatusRunning},
+		"id-db":  {ID: "id-db", Name: "db", Status: StatusRunning},
+	}
+	m.state.filterQuery = "web"
+	m.state.filteredIDs = []string{"id-web"}
+	m.state.filteredTiers = []Tier{
+		{Name: "tier1", Services: []string{"id-web"}},
+	}
+	m.state.selected = 0
+
+	teaModel, cmd := m.handleStopKey()
+	result := teaModel.(Model)
+
+	assert.True(t, result.loader.Has("id-web"))
+	assert.NotNil(t, cmd)
+}
+
+func Test_HandleStopKey_ZeroMatches_IsNoop(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockController := NewMockController(ctrl)
+	loader := &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}
+
+	m := Model{loader: loader, controller: mockController}
+	m.state.serviceIDs = []string{"id-api"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api", Status: StatusRunning},
+	}
+	m.state.filterQuery = "xyz"
+	m.state.filteredIDs = []string{}
+	m.state.filteredTiers = []Tier{}
+	m.state.selected = 0
+
+	teaModel, cmd := m.handleStopKey()
+	result := teaModel.(Model)
+
+	assert.False(t, result.loader.Active)
+	assert.Nil(t, cmd)
+}
+
+func Test_HandleRestartKey_WithFilter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockController := NewMockController(ctrl)
+	mockController.EXPECT().Restart(bus.Service{ID: "id-db", Name: "db"})
+
+	loader := &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}
+
+	m := Model{loader: loader, controller: mockController}
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api", Status: StatusRunning},
+		"id-web": {ID: "id-web", Name: "web", Status: StatusRunning},
+		"id-db":  {ID: "id-db", Name: "db", Status: StatusRunning},
+	}
+	m.state.filterQuery = "db"
+	m.state.filteredIDs = []string{"id-db"}
+	m.state.filteredTiers = []Tier{
+		{Name: "tier1", Services: []string{"id-db"}},
+	}
+	m.state.selected = 0
+
+	teaModel, cmd := m.handleRestartKey()
+	result := teaModel.(Model)
+
+	assert.True(t, result.loader.Has("id-db"))
+	assert.NotNil(t, cmd)
+}
+
+func Test_HandleRestartKey_ZeroMatches_IsNoop(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockController := NewMockController(ctrl)
+	loader := &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}
+
+	m := Model{loader: loader, controller: mockController}
+	m.state.serviceIDs = []string{"id-api"}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {ID: "id-api", Name: "api", Status: StatusRunning},
+	}
+	m.state.filterQuery = "xyz"
+	m.state.filteredIDs = []string{}
+	m.state.filteredTiers = []Tier{}
+	m.state.selected = 0
+
+	teaModel, cmd := m.handleRestartKey()
+	result := teaModel.(Model)
+
+	assert.False(t, result.loader.Active)
+	assert.Nil(t, cmd)
+}
+
+func Test_CalculateScrollOffset_WithFilter(t *testing.T) {
+	m := Model{}
+	m.state.serviceIDs = []string{"id-api", "id-web", "id-db", "id-cache"}
+	m.state.services = map[string]*ServiceState{
+		"id-api":   {ID: "id-api", Name: "api"},
+		"id-web":   {ID: "id-web", Name: "web"},
+		"id-db":    {ID: "id-db", Name: "db"},
+		"id-cache": {ID: "id-cache", Name: "cache"},
+	}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"id-api", "id-web"}},
+		{Name: "tier2", Services: []string{"id-db", "id-cache"}},
+	}
+	m.state.filterQuery = "b"
+	m.state.filteredIDs = []string{"id-web", "id-db"}
+	m.state.filteredTiers = []Tier{
+		{Name: "tier1", Services: []string{"id-web"}},
+		{Name: "tier2", Services: []string{"id-db"}},
+	}
+	m.state.selected = 1
+	m.ui.servicesViewport = viewport.New()
+	m.ui.servicesViewport.SetWidth(80)
+	m.ui.servicesViewport.SetHeight(3)
+
+	offset := m.calculateScrollOffset()
+
+	assert.Equal(t, 3, offset)
 }
 
 func toKeyMsg(s string) tea.KeyPressMsg {

--- a/internal/app/ui/services/view.go
+++ b/internal/app/ui/services/view.go
@@ -21,11 +21,13 @@ func (m Model) View() tea.View {
 	panelWidth := m.ui.width
 	panelHeight := m.ui.height - components.PanelHeightPadding
 
+	m.ui.servicesKeys.ClearFilter.SetEnabled(m.state.filterQuery != "")
+
 	panel := components.RenderPanel(components.PanelOptions{
 		Title:   m.renderTitle(),
 		Content: m.renderServices(),
 		Status:  m.renderStatus(),
-		Stats:   m.renderAppStats(),
+		Stats:   m.renderBottomLeft(),
 		Version: m.renderVersion(),
 		Help:    m.renderHelp(),
 		Tips:    m.renderTip(),
@@ -41,8 +43,8 @@ func (m Model) View() tea.View {
 
 // renderStatus renders the status bar with phase and service counts
 func (m Model) renderStatus() string {
-	ready := m.getReadyServices()
-	total := m.getTotalServices()
+	ready := m.getAllReadyServices()
+	total := len(m.state.serviceIDs)
 
 	phaseStr := string(m.state.phase)
 	phaseStyle := m.theme.PhaseMutedStyle
@@ -143,7 +145,50 @@ func (m Model) renderServices() string {
 		return m.theme.EmptyStateStyle.Render("no services configured")
 	}
 
+	if m.isFiltering() && len(m.state.filteredIDs) == 0 {
+		return m.theme.EmptyStateStyle.Render("no matching services")
+	}
+
 	return m.ui.servicesViewport.View()
+}
+
+// renderBottomLeft combines the filter bar and app stats for the bottom border
+func (m Model) renderBottomLeft() string {
+	filterBar := m.renderFilterBar()
+	appStats := m.renderAppStats()
+
+	switch {
+	case filterBar != "" && appStats != "":
+		return filterBar + m.theme.PanelMutedStyle.Render(" • ") + appStats
+	case filterBar != "":
+		return filterBar
+	default:
+		return appStats
+	}
+}
+
+// renderFilterBar renders the filter input indicator
+func (m Model) renderFilterBar() string {
+	if !m.state.filterActive && m.state.filterQuery == "" {
+		return ""
+	}
+
+	query := m.state.filterQuery
+
+	maxLen := max(m.ui.width/3-4, 0)
+	if maxLen > 0 {
+		runes := []rune(query)
+		if len(runes) > maxLen {
+			query = string(runes[:maxLen])
+		}
+	}
+
+	text := "/ " + query
+	if m.state.filterActive {
+		text += "_"
+	}
+
+	return m.theme.PanelMutedStyle.Render(text)
 }
 
 // getRowWidth returns the available width for service rows

--- a/internal/app/ui/services/view_test.go
+++ b/internal/app/ui/services/view_test.go
@@ -103,6 +103,24 @@ func Test_RenderStatus_PhaseColors(t *testing.T) {
 	}
 }
 
+func Test_RenderStatus_ShowsGlobalCountsWhenFiltering(t *testing.T) {
+	m := Model{}
+	m.state.phase = bus.PhaseRunning
+	m.state.serviceIDs = []string{"id-svc1", "id-svc2", "id-svc3"}
+	m.state.services = map[string]*ServiceState{
+		"id-svc1": {Status: StatusRunning},
+		"id-svc2": {Status: StatusFailed},
+		"id-svc3": {Status: StatusRunning},
+	}
+	m.state.filterQuery = "svc1"
+	m.state.filteredIDs = []string{"id-svc1"}
+	m.state.filteredTiers = []Tier{{Name: "tier1", Services: []string{"id-svc1"}}}
+	m.theme = components.DefaultTheme()
+
+	result := m.renderStatus()
+	assert.Contains(t, result, "2/3 ready")
+}
+
 func Test_RenderServices_Empty(t *testing.T) {
 	m := Model{}
 	m.state.tiers = []Tier{}
@@ -836,4 +854,216 @@ func Test_RenderAppStats(t *testing.T) {
 			assert.Equal(t, tt.want, m.renderAppStats())
 		})
 	}
+}
+
+func Test_RenderServices_FilteredNoMatches(t *testing.T) {
+	m := Model{}
+	m.state.tiers = []Tier{{Name: "tier1", Services: []string{"api"}}}
+	m.state.services = map[string]*ServiceState{"api": {Name: "api", Status: StatusRunning}}
+	m.state.filterQuery = "nonexistent"
+	m.state.filteredIDs = []string{}
+	m.state.filteredTiers = []Tier{}
+	m.ui.servicesViewport = viewport.New(viewport.WithWidth(80), viewport.WithHeight(20))
+
+	result := m.renderServices()
+	assert.Contains(t, result, "no matching services")
+}
+
+func Test_RenderServices_FilteredWithMatches(t *testing.T) {
+	m := Model{}
+	m.state.tiers = []Tier{{Name: "tier1", Services: []string{"api", "web"}}}
+	m.state.services = map[string]*ServiceState{
+		"api": {Name: "api", Status: StatusRunning},
+		"web": {Name: "web", Status: StatusRunning},
+	}
+	m.state.filterQuery = "api"
+	m.state.filteredIDs = []string{"api"}
+	m.state.filteredTiers = []Tier{{Name: "tier1", Services: []string{"api"}}}
+	m.ui.servicesViewport = viewport.New(viewport.WithWidth(80), viewport.WithHeight(20))
+	m.ui.layout = layoutForWidth(80)
+	m.theme = components.DefaultTheme()
+	m.updateServicesContent()
+
+	result := m.renderServices()
+	assert.Contains(t, result, "api")
+	assert.NotContains(t, result, "web")
+	assert.NotContains(t, result, "no matching services")
+	assert.NotContains(t, result, "no services configured")
+}
+
+func Test_RenderFilterBar(t *testing.T) {
+	tests := []struct {
+		name         string
+		filterActive bool
+		filterQuery  string
+		wantEmpty    bool
+		wantContains string
+	}{
+		{
+			name:         "no filter active and no query",
+			filterActive: false,
+			filterQuery:  "",
+			wantEmpty:    true,
+		},
+		{
+			name:         "filter active with empty query shows cursor",
+			filterActive: true,
+			filterQuery:  "",
+			wantContains: "/ _",
+		},
+		{
+			name:         "filter active with query shows cursor",
+			filterActive: true,
+			filterQuery:  "api",
+			wantContains: "/ api_",
+		},
+		{
+			name:         "filter not active but query retained without cursor",
+			filterActive: false,
+			filterQuery:  "web",
+			wantContains: "/ web",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := Model{}
+			m.theme = components.DefaultTheme()
+			m.state.filterActive = tt.filterActive
+			m.state.filterQuery = tt.filterQuery
+
+			result := m.renderFilterBar()
+
+			if tt.wantEmpty {
+				assert.Empty(t, result)
+			} else {
+				assert.Contains(t, result, tt.wantContains)
+			}
+		})
+	}
+}
+
+func Test_View_FilterBarInBottomBorder(t *testing.T) {
+	loader := &Loader{Model: spinner.New(), Active: false, queue: make([]LoaderItem, 0)}
+	m := Model{loader: loader}
+	m.state.ready = true
+	m.state.profile = "default"
+	m.state.phase = bus.PhaseRunning
+	m.state.services = map[string]*ServiceState{"api": {Name: "api", Status: StatusRunning}}
+	m.state.tiers = []Tier{{Name: "tier1", Services: []string{"api"}}}
+	m.state.serviceIDs = []string{"api"}
+	m.state.filterQuery = "api"
+	m.state.filterActive = true
+	m.state.filteredIDs = []string{"api"}
+	m.state.filteredTiers = []Tier{{Name: "tier1", Services: []string{"api"}}}
+	m.ui.width = 100
+	m.ui.height = 50
+	m.ui.layout = layoutForWidth(100 - components.PanelInnerPadding)
+	m.ui.help = help.New()
+	m.ui.servicesKeys = DefaultKeyMap()
+	m.ui.servicesViewport = viewport.New(viewport.WithWidth(80), viewport.WithHeight(30))
+	m.theme = components.DefaultTheme()
+
+	result := m.View()
+
+	assert.Contains(t, result.Content, "/ api_")
+	assert.Contains(t, result.Content, "profile")
+}
+
+func Test_RenderBottomLeft_CombinesFilterAndStats(t *testing.T) {
+	theme := components.DefaultTheme()
+	m := Model{theme: theme}
+	m.state.filterQuery = "svc"
+	m.state.filterActive = false
+	m.state.appCPU = 5.0
+	m.state.appMEM = 128
+	m.ui.width = 100
+
+	result := m.renderBottomLeft()
+
+	assert.Contains(t, result, "/ svc")
+	assert.Contains(t, result, "cpu 5.0%")
+	assert.Contains(t, result, "mem 128MB")
+}
+
+func Test_RenderBottomLeft_FilterOnlyWhenNoStats(t *testing.T) {
+	theme := components.DefaultTheme()
+	m := Model{theme: theme}
+	m.state.filterQuery = "web"
+	m.state.filterActive = false
+	m.ui.width = 100
+
+	result := m.renderBottomLeft()
+
+	assert.Contains(t, result, "/ web")
+}
+
+func Test_RenderBottomLeft_StatsOnlyWhenNoFilter(t *testing.T) {
+	theme := components.DefaultTheme()
+	m := Model{theme: theme}
+	m.state.appCPU = 2.0
+	m.state.appMEM = 64
+
+	result := m.renderBottomLeft()
+
+	assert.Contains(t, result, "cpu 2.0%")
+	assert.NotContains(t, result, "/")
+}
+
+func Test_RenderFilterBar_TruncatesLongQuery(t *testing.T) {
+	m := Model{}
+	m.theme = components.DefaultTheme()
+	m.ui.width = 40
+	m.state.filterActive = true
+	m.state.filterQuery = "this-is-a-very-long-service-name-filter-query"
+
+	result := m.renderFilterBar()
+
+	assert.Contains(t, result, "/ this")
+	assert.NotContains(t, result, "filter-query")
+}
+
+func Test_UpdateServicesContent_UsesFilteredTiers(t *testing.T) {
+	m := Model{}
+	m.state.tiers = []Tier{
+		{Name: "tier1", Services: []string{"api", "web"}},
+		{Name: "tier2", Services: []string{"db"}},
+	}
+	m.state.services = map[string]*ServiceState{
+		"api": {Name: "api", Status: StatusRunning},
+		"web": {Name: "web", Status: StatusRunning},
+		"db":  {Name: "db", Status: StatusRunning},
+	}
+	m.state.serviceIDs = []string{"api", "web", "db"}
+	m.state.filterQuery = "api"
+	m.state.filteredIDs = []string{"api"}
+	m.state.filteredTiers = []Tier{{Name: "tier1", Services: []string{"api"}}}
+	m.ui.width = 100
+	m.ui.layout = layoutForWidth(92)
+	m.ui.servicesViewport = viewport.New(viewport.WithWidth(92), viewport.WithHeight(20))
+	m.theme = components.DefaultTheme()
+
+	m.updateServicesContent()
+
+	content := m.ui.servicesViewport.View()
+	assert.Contains(t, content, "api")
+	assert.NotContains(t, content, "db")
+}
+
+func Test_UpdateServicesContent_EmptyFilterClearsViewport(t *testing.T) {
+	m := Model{}
+	m.state.tiers = []Tier{{Name: "tier1", Services: []string{"api"}}}
+	m.state.services = map[string]*ServiceState{
+		"api": {Name: "api", Status: StatusRunning},
+	}
+	m.state.filterQuery = "nonexistent"
+	m.state.filteredIDs = []string{}
+	m.state.filteredTiers = []Tier{}
+	m.ui.servicesViewport = viewport.New(viewport.WithWidth(80), viewport.WithHeight(20))
+
+	m.updateServicesContent()
+
+	content := m.ui.servicesViewport.View()
+	assert.NotContains(t, content, "api")
+	assert.NotContains(t, content, "tier1")
 }


### PR DESCRIPTION
Add / keypress to filter services by name in the TUI 
Arrow keys navigate filtered results during input mode, Enter confirms the filter for j/k/s/r navigation, and Esc clears it