### PR TITLE
feat(ui): Add per-service readiness timeline

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -95,11 +95,11 @@ type Bus interface {
 
 The Bus implements a unified pub/sub pattern for both events and commands:
 
-- **Non-blocking publish**: Messages are sent to subscriber channels without blocking
-- **Critical messages**: Important messages (phase changes) block until delivered
+- **Globally serialized publish**: A dedicated publish mutex ensures all subscribers observe messages in the same order as their assigned sequence numbers
+- **Monotonic sequencing**: Each message receives a strictly increasing `Seq` for downstream ordering and stale-event rejection
+- **Critical-only overflow**: When a subscriber's channel is full, critical messages (lifecycle events, commands) are queued in a FIFO overflow buffer; non-critical messages (telemetry, samples) are dropped
 - **Context-aware cleanup**: Subscribers auto-unsubscribe when context cancels
-- **Buffered channels**: Prevents slow subscribers from blocking publishers
-- **Log broadcasting**: Server is injected at construction time via FX dependency injection
+- **Buffered channels**: Configurable per-subscriber buffer size from `config.Logs.Buffer`
 
 ### Message Types
 
@@ -693,8 +693,10 @@ The store maintains per-service state from bus lifecycle events:
 
 - **Status** — `registry.Status` type with typed constants
 - **PID, CPU, Memory** — sampled on a fixed interval with PID recheck to prevent stale stats after restarts
-- **StartTime** — recorded from `msg.Timestamp` (publish time, not dequeue time) for accurate uptime
+- **StartTime** — recorded from the lifecycle event `StartedAt` field for accurate uptime
 - **Instance uptime** — starts from `PhaseStartup`, includes startup duration
+- **Lifecycle sequencing** — each lifecycle/watch event carries a monotonic sequence number (`LifecycleSeq`, `WatchSeq`) for stale-event rejection and UI reconciliation
+- **Attempt tracking** — `AttemptStartedAt` records when each startup attempt began, enabling accurate timeline backfill across retries
 
 ```go
 type Store interface {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,6 +285,7 @@
 - `cmd/main_test.go` - Tests for entry point functions and FX application creation
 - `internal/app/app_test.go` - Application container and lifecycle testing
 - `internal/app/bus/bus_test.go` - Bus pub/sub messaging testing
+- `internal/app/bus/subscriber_test.go` - Subscriber overflow and FIFO drain testing
 - `internal/app/cli/cli_test.go` - CLI command execution testing
 - `internal/app/cli/commands_test.go` - Cobra command parsing tests
 - `internal/app/discovery/discovery_test.go` - Profile resolution testing
@@ -304,6 +305,7 @@
 - `internal/app/process/process_test.go` - Process handle testing
 - `internal/app/readiness/readiness_test.go` - Readiness check testing
 - `internal/app/registry/registry_test.go` - Process registry testing
+- `internal/app/registry/store_test.go` - Runtime state store testing
 - `internal/app/runner/guard_test.go` - Restart guard testing
 - `internal/app/runner/runner_test.go` - Service orchestration and tier ordering
 - `internal/app/runner/service_test.go` - Service start/stop/restart testing
@@ -320,6 +322,7 @@
 - `internal/app/ui/services/model_test.go` - Service state methods and helpers
 - `internal/app/ui/services/monitor_test.go` - CPU/memory formatting functions
 - `internal/app/ui/services/state_test.go` - FSM state transitions and callbacks
+- `internal/app/ui/services/timeline_test.go` - Timeline ring buffer and slot mapping
 - `internal/app/ui/services/update_test.go` - Event handlers
 - `internal/app/ui/services/view_test.go` - View rendering functions
 - `internal/app/ui/wire/module_test.go` - UI wire module testing

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Features
 
-- **Interactive TUI** - Real-time service monitoring with status, CPU, memory, and uptime
+- **Interactive TUI** - Real-time service monitoring with status, readiness timeline, CPU, memory, and uptime
 - **Service Orchestration** - Tier-based startup ordering
 - **Service Control** - Start, stop, and restart services interactively
 - **Graceful Shutdown** - SIGTERM with timeout before force kill

--- a/internal/app/bus/bus.go
+++ b/internal/app/bus/bus.go
@@ -3,6 +3,7 @@ package bus
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"fuku/internal/config"
@@ -60,6 +61,7 @@ const (
 // Message represents a bus message (event or command)
 type Message struct {
 	Type      MessageType
+	Seq       uint64
 	Timestamp time.Time
 	Data      any
 	Critical  bool
@@ -148,8 +150,9 @@ func (e ServiceEvent) ServiceID() string {
 // ServiceStarting indicates a service is starting with attempt and process info
 type ServiceStarting struct {
 	ServiceEvent
-	Attempt int
-	PID     int
+	Attempt   int
+	PID       int
+	StartedAt time.Time
 }
 
 // ReadinessComplete indicates a readiness check has finished successfully
@@ -162,7 +165,9 @@ type ReadinessComplete struct {
 // ServiceReady indicates a service has completed startup and is ready
 type ServiceReady struct {
 	ServiceEvent
-	Duration time.Duration
+	PID       int
+	StartedAt time.Time
+	Duration  time.Duration
 }
 
 // ServiceFailed indicates a service failed to start or crashed
@@ -230,9 +235,11 @@ type Bus interface {
 // bus implements the Bus interface with pub/sub messaging
 type bus struct {
 	cfg         *config.Config
-	subscribers []chan Message
+	subscribers []*subscriber
 	mu          sync.RWMutex
+	publishMu   sync.Mutex
 	closed      bool
+	seq         atomic.Uint64
 	formatter   *Formatter
 	log         logger.Logger
 }
@@ -241,7 +248,7 @@ type bus struct {
 func NewBus(cfg *config.Config, formatter *Formatter, log logger.Logger) Bus {
 	return &bus{
 		cfg:         cfg,
-		subscribers: make([]chan Message, 0),
+		subscribers: make([]*subscriber, 0),
 		formatter:   formatter,
 		log:         log,
 	}
@@ -252,19 +259,22 @@ func (b *bus) Subscribe(ctx context.Context) <-chan Message {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	ch := make(chan Message, b.cfg.Logs.Buffer)
-	b.subscribers = append(b.subscribers, ch)
+	sub := newSubscriber(b.cfg.Logs.Buffer)
+	b.subscribers = append(b.subscribers, sub)
 
 	go func() {
 		<-ctx.Done()
-		b.unsubscribe(ch)
+		b.unsubscribe(sub)
 	}()
 
-	return ch
+	return sub.ch
 }
 
 // Publish sends a message to all subscribers
 func (b *bus) Publish(msg Message) {
+	b.publishMu.Lock()
+	defer b.publishMu.Unlock()
+
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
@@ -272,6 +282,7 @@ func (b *bus) Publish(msg Message) {
 		return
 	}
 
+	msg.Seq = b.seq.Add(1)
 	msg.Timestamp = time.Now()
 
 	if b.formatter != nil && b.log != nil {
@@ -279,21 +290,8 @@ func (b *bus) Publish(msg Message) {
 		b.log.Debug().Msg(text)
 	}
 
-	for _, ch := range b.subscribers {
-		select {
-		case ch <- msg:
-		default:
-			if msg.Critical {
-				go func(c chan Message, m Message) {
-					defer func() {
-						//nolint:errcheck // recover return value is intentionally unused
-						recover()
-					}()
-
-					c <- m
-				}(ch, msg)
-			}
-		}
+	for _, sub := range b.subscribers {
+		sub.send(msg)
 	}
 }
 
@@ -308,22 +306,22 @@ func (b *bus) Close() {
 
 	b.closed = true
 
-	for _, ch := range b.subscribers {
-		close(ch)
+	for _, sub := range b.subscribers {
+		sub.close()
 	}
 
 	b.subscribers = nil
 }
 
-func (b *bus) unsubscribe(ch chan Message) {
+func (b *bus) unsubscribe(sub *subscriber) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	for i, sub := range b.subscribers {
-		if sub == ch {
+	for i, s := range b.subscribers {
+		if s == sub {
 			b.subscribers = append(b.subscribers[:i], b.subscribers[i+1:]...)
 
-			close(ch)
+			sub.close()
 
 			break
 		}

--- a/internal/app/bus/bus_test.go
+++ b/internal/app/bus/bus_test.go
@@ -3,6 +3,7 @@ package bus
 import (
 	"context"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -47,11 +48,37 @@ func Test_Bus_PublishSubscribe(t *testing.T) {
 	select {
 	case msg := <-ch:
 		assert.Equal(t, EventServiceReady, msg.Type)
+		assert.Equal(t, uint64(1), msg.Seq)
 		data, ok := msg.Data.(ServiceReady)
 		assert.True(t, ok)
 		assert.Equal(t, "api", data.Service.Name)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("Expected message")
+	}
+}
+
+func Test_Bus_SeqIsMonotonic(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logs.Buffer = 10
+
+	b := NewBus(cfg, nil, nil)
+	defer b.Close()
+
+	ch := b.Subscribe(t.Context())
+
+	for i := range 5 {
+		b.Publish(Message{
+			Type: EventServiceStarting,
+			Data: ServiceStarting{ServiceEvent: ServiceEvent{Service: Service{ID: "api"}, Tier: "default"}, PID: i},
+		})
+	}
+
+	var lastSeq uint64
+
+	for range 5 {
+		msg := <-ch
+		assert.Greater(t, msg.Seq, lastSeq)
+		lastSeq = msg.Seq
 	}
 }
 
@@ -267,4 +294,233 @@ func Test_NoOp_Methods(t *testing.T) {
 
 	b.Publish(Message{Type: EventPhaseChanged})
 	b.Close()
+}
+
+func Test_Bus_CriticalFIFO_PublishOrderPreserved(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logs.Buffer = 1
+
+	b := NewBus(cfg, nil, nil)
+	defer b.Close()
+
+	ch := b.Subscribe(t.Context())
+
+	events := []Message{
+		{Type: EventServiceStarting, Critical: true},
+		{Type: EventServiceReady, Critical: true},
+		{Type: EventServiceStopping, Critical: true},
+		{Type: EventServiceStopped, Critical: true},
+	}
+
+	for _, e := range events {
+		b.Publish(e)
+	}
+
+	received := make([]MessageType, 0, len(events))
+	timeout := time.After(time.Second)
+
+	for range events {
+		select {
+		case msg := <-ch:
+			received = append(received, msg.Type)
+		case <-timeout:
+			t.Fatalf("timed out after receiving %d/%d messages", len(received), len(events))
+		}
+	}
+
+	expected := []MessageType{
+		EventServiceStarting,
+		EventServiceReady,
+		EventServiceStopping,
+		EventServiceStopped,
+	}
+
+	assert.Equal(t, expected, received, "critical messages must be received in exact publish order")
+}
+
+func Test_Bus_Subscriber_CloseWithOverflow_NoPanic(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logs.Buffer = 1
+
+	b := NewBus(cfg, nil, nil)
+
+	ch := b.Subscribe(t.Context())
+
+	b.Publish(Message{Type: EventPhaseChanged})
+
+	b.Publish(Message{Type: EventServiceStarting, Critical: true})
+	b.Publish(Message{Type: EventServiceReady, Critical: true})
+
+	b.Close()
+
+	drained := 0
+
+	for range ch {
+		drained++
+	}
+
+	assert.GreaterOrEqual(t, drained, 1, "should have received at least the buffered message")
+}
+
+func Test_Bus_Unsubscribe_WithOverflow_NoPanic(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logs.Buffer = 1
+
+	b := NewBus(cfg, nil, nil)
+	defer b.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := b.Subscribe(ctx)
+
+	b.Publish(Message{Type: EventPhaseChanged})
+
+	b.Publish(Message{Type: EventServiceStarting, Critical: true})
+
+	cancel()
+
+	closed := false
+	timeout := time.After(time.Second)
+
+loop:
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				closed = true
+
+				break loop
+			}
+		case <-timeout:
+			break loop
+		}
+	}
+
+	assert.True(t, closed, "channel should close after context cancel with overflow")
+}
+
+func Test_Bus_ConcurrentPublish_PreservesSubscriberOrder(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logs.Buffer = 1000
+
+	b := NewBus(cfg, nil, nil)
+	defer b.Close()
+
+	ch := b.Subscribe(t.Context())
+
+	const (
+		publishers   = 4
+		perPublisher = 50
+	)
+
+	total := publishers * perPublisher
+
+	var wg sync.WaitGroup
+
+	for range publishers {
+		wg.Go(func() {
+			for range perPublisher {
+				b.Publish(Message{Type: EventResourceSample})
+			}
+		})
+	}
+
+	wg.Wait()
+
+	var lastSeq uint64
+
+	timeout := time.After(time.Second)
+
+	for range total {
+		select {
+		case msg := <-ch:
+			assert.Greater(t, msg.Seq, lastSeq, "seq must be strictly increasing")
+			lastSeq = msg.Seq
+		case <-timeout:
+			t.Fatal("timed out waiting for messages")
+		}
+	}
+}
+
+func Test_Bus_ConcurrentLifecyclePublish_NoInversion(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logs.Buffer = 100
+
+	b := NewBus(cfg, nil, nil)
+	defer b.Close()
+
+	ch := b.Subscribe(t.Context())
+
+	const (
+		goroutines   = 2
+		perGoroutine = 25
+	)
+
+	var wg sync.WaitGroup
+
+	for range goroutines {
+		wg.Go(func() {
+			for range perGoroutine {
+				b.Publish(Message{
+					Type:     EventServiceStarting,
+					Critical: true,
+				})
+			}
+		})
+	}
+
+	wg.Wait()
+
+	total := goroutines * perGoroutine
+
+	var lastSeq uint64
+
+	timeout := time.After(time.Second)
+
+	for range total {
+		select {
+		case msg := <-ch:
+			assert.Greater(t, msg.Seq, lastSeq, "lifecycle seq must not invert")
+			lastSeq = msg.Seq
+		case <-timeout:
+			t.Fatal("timed out waiting for lifecycle messages")
+		}
+	}
+}
+
+func Test_Bus_CriticalOverflow_NonCriticalDropped(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Logs.Buffer = 1
+
+	b := NewBus(cfg, nil, nil)
+	defer b.Close()
+
+	ch := b.Subscribe(t.Context())
+
+	b.Publish(Message{Type: EventPhaseChanged})
+
+	b.Publish(Message{Type: EventServiceStarting, Critical: true})
+
+	b.Publish(Message{Type: EventResourceSample, Critical: false})
+	b.Publish(Message{Type: EventResourceSample, Critical: false})
+
+	received := make([]MessageType, 0, 2)
+	timeout := time.After(time.Second)
+
+	for range 2 {
+		select {
+		case msg := <-ch:
+			received = append(received, msg.Type)
+		case <-timeout:
+			t.Fatalf("timed out after %d/2 messages", len(received))
+		}
+	}
+
+	assert.Equal(t, EventPhaseChanged, received[0])
+	assert.Equal(t, EventServiceStarting, received[1])
+
+	select {
+	case <-ch:
+		t.Fatal("non-critical traffic must not be retained")
+	case <-time.After(50 * time.Millisecond):
+	}
 }

--- a/internal/app/bus/subscriber.go
+++ b/internal/app/bus/subscriber.go
@@ -1,0 +1,131 @@
+package bus
+
+import "sync"
+
+// subscriber wraps a channel with a FIFO overflow queue for critical messages
+type subscriber struct {
+	ch       chan Message
+	overflow []Message
+	signal   chan struct{}
+	quit     chan struct{}
+	done     chan struct{}
+	mu       sync.Mutex
+	closed   bool
+}
+
+func newSubscriber(bufferSize int) *subscriber {
+	s := &subscriber{
+		ch:     make(chan Message, bufferSize),
+		signal: make(chan struct{}, 1),
+		quit:   make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+
+	go s.pump()
+
+	return s
+}
+
+// send attempts a non-blocking send; if full and critical, queues for FIFO drain
+func (s *subscriber) send(msg Message) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+
+		return
+	}
+
+	switch {
+	case len(s.overflow) > 0 && msg.Critical:
+		s.overflow = append(s.overflow, msg)
+		s.mu.Unlock()
+		s.notify()
+
+		return
+	case len(s.overflow) > 0:
+		s.mu.Unlock()
+
+		return
+	}
+	s.mu.Unlock()
+
+	select {
+	case s.ch <- msg:
+		return
+	default:
+	}
+
+	if !msg.Critical {
+		return
+	}
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+
+		return
+	}
+
+	s.overflow = append(s.overflow, msg)
+	s.mu.Unlock()
+	s.notify()
+}
+
+// notify signals the pump goroutine that overflow has messages to drain
+func (s *subscriber) notify() {
+	select {
+	case s.signal <- struct{}{}:
+	default:
+	}
+}
+
+// pump drains overflow messages into the channel in FIFO order
+func (s *subscriber) pump() {
+	defer close(s.done)
+
+	for {
+		select {
+		case <-s.signal:
+		case <-s.quit:
+			return
+		}
+
+		for {
+			s.mu.Lock()
+			if len(s.overflow) == 0 {
+				s.mu.Unlock()
+
+				break
+			}
+
+			msg := s.overflow[0]
+			s.mu.Unlock()
+
+			select {
+			case s.ch <- msg:
+				s.mu.Lock()
+				s.overflow = s.overflow[1:]
+				s.mu.Unlock()
+			case <-s.quit:
+				return
+			}
+		}
+	}
+}
+
+// close stops the pump goroutine and closes the channel
+func (s *subscriber) close() {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+
+		return
+	}
+
+	s.closed = true
+	s.mu.Unlock()
+
+	close(s.quit)
+	<-s.done
+	close(s.ch)
+}

--- a/internal/app/bus/subscriber_test.go
+++ b/internal/app/bus/subscriber_test.go
@@ -1,0 +1,190 @@
+package bus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewSubscriber(t *testing.T) {
+	sub := newSubscriber(10)
+	defer sub.close()
+
+	assert.NotNil(t, sub.ch)
+	assert.Equal(t, 10, cap(sub.ch))
+}
+
+func Test_Subscriber_Send(t *testing.T) {
+	sub := newSubscriber(5)
+	defer sub.close()
+
+	sub.send(Message{Type: EventPhaseChanged})
+
+	select {
+	case msg := <-sub.ch:
+		assert.Equal(t, EventPhaseChanged, msg.Type)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("message not received")
+	}
+}
+
+func Test_Subscriber_Send_DropsNonCriticalWhenFull(t *testing.T) {
+	sub := newSubscriber(1)
+	defer sub.close()
+
+	sub.ch <- Message{Type: EventPhaseChanged}
+
+	sub.send(Message{Type: EventResourceSample, Critical: false})
+
+	sub.mu.Lock()
+	overflowLen := len(sub.overflow)
+	sub.mu.Unlock()
+
+	assert.Equal(t, 0, overflowLen)
+}
+
+func Test_Subscriber_Send_QueuesCriticalWhenFull(t *testing.T) {
+	sub := newSubscriber(1)
+	defer sub.close()
+
+	sub.ch <- Message{Type: EventPhaseChanged}
+
+	sub.send(Message{Type: EventServiceReady, Critical: true})
+
+	sub.mu.Lock()
+	overflowLen := len(sub.overflow)
+	sub.mu.Unlock()
+
+	assert.Equal(t, 1, overflowLen)
+}
+
+func Test_Subscriber_Send_SkipsWhenClosed(t *testing.T) {
+	sub := newSubscriber(5)
+	sub.close()
+
+	sub.send(Message{Type: EventPhaseChanged})
+
+	sub.mu.Lock()
+	overflowLen := len(sub.overflow)
+	sub.mu.Unlock()
+
+	assert.Equal(t, 0, overflowLen)
+}
+
+func Test_Subscriber_Send_CriticalSkipsWhenClosed(t *testing.T) {
+	sub := newSubscriber(1)
+
+	sub.ch <- Message{Type: EventPhaseChanged}
+
+	sub.close()
+
+	sub.send(Message{Type: EventServiceReady, Critical: true})
+
+	sub.mu.Lock()
+	overflowLen := len(sub.overflow)
+	sub.mu.Unlock()
+
+	assert.Equal(t, 0, overflowLen)
+}
+
+func Test_Subscriber_OverflowFIFO(t *testing.T) {
+	sub := newSubscriber(1)
+	defer sub.close()
+
+	sub.ch <- Message{Type: EventPhaseChanged}
+
+	sub.send(Message{Type: EventServiceStarting, Critical: true, Seq: 1})
+	sub.send(Message{Type: EventServiceReady, Critical: true, Seq: 2})
+
+	sub.mu.Lock()
+	assert.Len(t, sub.overflow, 2)
+	assert.Equal(t, EventServiceStarting, sub.overflow[0].Type)
+	assert.Equal(t, EventServiceReady, sub.overflow[1].Type)
+	sub.mu.Unlock()
+}
+
+func Test_Subscriber_PumpDrainsOverflow(t *testing.T) {
+	sub := newSubscriber(1)
+	defer sub.close()
+
+	sub.ch <- Message{Type: EventPhaseChanged}
+
+	sub.send(Message{Type: EventServiceStarting, Critical: true})
+	sub.send(Message{Type: EventServiceReady, Critical: true})
+
+	received := make([]MessageType, 0, 3)
+	timeout := time.After(time.Second)
+
+	for range 3 {
+		select {
+		case msg := <-sub.ch:
+			received = append(received, msg.Type)
+		case <-timeout:
+			t.Fatalf("timed out after %d/3 messages", len(received))
+		}
+	}
+
+	assert.Equal(t, []MessageType{
+		EventPhaseChanged,
+		EventServiceStarting,
+		EventServiceReady,
+	}, received)
+}
+
+func Test_Subscriber_Close(t *testing.T) {
+	sub := newSubscriber(5)
+
+	sub.send(Message{Type: EventPhaseChanged})
+
+	sub.close()
+
+	_, ok := <-sub.ch
+	if ok {
+		_, ok = <-sub.ch
+	}
+
+	assert.False(t, ok, "channel should be closed")
+}
+
+func Test_Subscriber_Close_Idempotent(t *testing.T) {
+	sub := newSubscriber(5)
+
+	sub.close()
+	sub.close()
+}
+
+func Test_Subscriber_Close_WithPendingOverflow(t *testing.T) {
+	sub := newSubscriber(1)
+
+	sub.ch <- Message{Type: EventPhaseChanged}
+
+	sub.send(Message{Type: EventServiceStarting, Critical: true})
+	sub.send(Message{Type: EventServiceReady, Critical: true})
+
+	sub.close()
+
+	drained := 0
+
+	for range sub.ch {
+		drained++
+	}
+
+	assert.GreaterOrEqual(t, drained, 1)
+}
+
+func Test_Subscriber_Send_DropsNonCriticalWhileOverflowDrains(t *testing.T) {
+	sub := newSubscriber(1)
+	defer sub.close()
+
+	sub.ch <- Message{Type: EventPhaseChanged}
+
+	sub.send(Message{Type: EventServiceStarting, Critical: true})
+
+	sub.send(Message{Type: EventResourceSample, Critical: false})
+
+	sub.mu.Lock()
+	assert.Len(t, sub.overflow, 1)
+	assert.Equal(t, EventServiceStarting, sub.overflow[0].Type)
+	sub.mu.Unlock()
+}

--- a/internal/app/registry/store.go
+++ b/internal/app/registry/store.go
@@ -47,16 +47,21 @@ func (s Status) IsRestartable() bool {
 
 // ServiceSnapshot contains a point-in-time snapshot of a service
 type ServiceSnapshot struct {
-	ID        string
-	Name      string
-	Tier      string
-	Status    Status
-	Watching  bool
-	Error     string
-	PID       int
-	CPU       float64
-	Memory    uint64
-	StartTime time.Time
+	ID               string
+	Name             string
+	Tier             string
+	Status           Status
+	Watching         bool
+	Error            string
+	PID              int
+	CPU              float64
+	Memory           uint64
+	StartTime        time.Time
+	AttemptStartedAt time.Time
+	LifecycleAt      time.Time
+	LifecycleSeq     uint64
+	WatchAt          time.Time
+	WatchSeq         uint64
 }
 
 // StatusCounts contains service counts grouped by status
@@ -86,16 +91,21 @@ type Store interface {
 
 // serviceState tracks the mutable state of a single service
 type serviceState struct {
-	id        string
-	name      string
-	tier      string
-	status    Status
-	watching  bool
-	err       string
-	pid       int
-	cpu       float64
-	memory    uint64
-	startTime time.Time
+	id               string
+	name             string
+	tier             string
+	status           Status
+	watching         bool
+	err              string
+	pid              int
+	cpu              float64
+	memory           uint64
+	startTime        time.Time
+	attemptStartedAt time.Time
+	lifecycleAt      time.Time
+	lifecycleSeq     uint64
+	watchAt          time.Time
+	watchSeq         uint64
 }
 
 // store implements the Store interface
@@ -287,16 +297,21 @@ func (s *store) decrementCount(status Status) {
 
 func (s *store) snapshot(svc *serviceState) ServiceSnapshot {
 	return ServiceSnapshot{
-		ID:        svc.id,
-		Name:      svc.name,
-		Tier:      svc.tier,
-		Status:    svc.status,
-		Watching:  svc.watching,
-		Error:     svc.err,
-		PID:       svc.pid,
-		CPU:       svc.cpu,
-		Memory:    svc.memory,
-		StartTime: svc.startTime,
+		ID:               svc.id,
+		Name:             svc.name,
+		Tier:             svc.tier,
+		Status:           svc.status,
+		Watching:         svc.watching,
+		Error:            svc.err,
+		PID:              svc.pid,
+		CPU:              svc.cpu,
+		Memory:           svc.memory,
+		StartTime:        svc.startTime,
+		AttemptStartedAt: svc.attemptStartedAt,
+		LifecycleAt:      svc.lifecycleAt,
+		LifecycleSeq:     svc.lifecycleSeq,
+		WatchAt:          svc.watchAt,
+		WatchSeq:         svc.watchSeq,
 	}
 }
 
@@ -313,7 +328,7 @@ func (s *store) handleEvent(msg bus.Message) {
 	case bus.EventServiceStarting:
 		s.handleServiceStarting(msg)
 	case bus.EventServiceReady:
-		s.setServiceStatus(msg, StatusRunning)
+		s.handleServiceReady(msg)
 	case bus.EventServiceFailed:
 		s.handleServiceFailed(msg)
 	case bus.EventServiceStopping:
@@ -321,7 +336,7 @@ func (s *store) handleEvent(msg bus.Message) {
 	case bus.EventServiceStopped:
 		s.handleServiceStopped(msg)
 	case bus.EventServiceRestarting:
-		s.setServiceStatus(msg, StatusRestarting)
+		s.handleServiceRestarting(msg)
 	case bus.EventWatchStarted:
 		s.setWatching(msg, true)
 	case bus.EventWatchStopped:
@@ -364,16 +379,46 @@ func (s *store) handleServiceStarting(msg bus.Message) {
 	}
 
 	svc, exists := s.services[data.Service.ID]
-	if !exists {
+	if !exists || msg.Seq <= svc.lifecycleSeq {
 		return
 	}
 
+	svc.lifecycleSeq = msg.Seq
+	svc.lifecycleAt = msg.Timestamp
 	s.transitionStatus(svc, StatusStarting)
 	svc.pid = data.PID
 	svc.err = ""
-	svc.startTime = msg.Timestamp
+	svc.startTime = data.StartedAt
+	svc.attemptStartedAt = data.StartedAt
 	svc.cpu = 0
 	svc.memory = 0
+}
+
+func (s *store) handleServiceReady(msg bus.Message) {
+	data, ok := msg.Data.(bus.ServiceReady)
+	if !ok {
+		return
+	}
+
+	svc, exists := s.services[data.Service.ID]
+	if !exists || msg.Seq <= svc.lifecycleSeq {
+		return
+	}
+
+	newProcess := svc.pid != data.PID || svc.startTime != data.StartedAt
+
+	svc.lifecycleSeq = msg.Seq
+	svc.lifecycleAt = msg.Timestamp
+	s.transitionStatus(svc, StatusRunning)
+	svc.pid = data.PID
+	svc.err = ""
+	svc.startTime = data.StartedAt
+	svc.attemptStartedAt = data.StartedAt
+
+	if newProcess {
+		svc.cpu = 0
+		svc.memory = 0
+	}
 }
 
 func (s *store) handleServiceStopped(msg bus.Message) {
@@ -383,16 +428,37 @@ func (s *store) handleServiceStopped(msg bus.Message) {
 	}
 
 	svc, exists := s.services[data.Service.ID]
-	if !exists {
+	if !exists || msg.Seq <= svc.lifecycleSeq {
 		return
 	}
 
+	svc.lifecycleSeq = msg.Seq
+	svc.lifecycleAt = msg.Timestamp
 	s.transitionStatus(svc, StatusStopped)
 	svc.pid = 0
 	svc.cpu = 0
 	svc.memory = 0
 	svc.startTime = time.Time{}
 	svc.err = ""
+}
+
+func (s *store) handleServiceRestarting(msg bus.Message) {
+	data, ok := msg.Data.(bus.ServiceRestarting)
+	if !ok {
+		return
+	}
+
+	svc, exists := s.services[data.Service.ID]
+	if !exists || msg.Seq <= svc.lifecycleSeq {
+		return
+	}
+
+	svc.lifecycleSeq = msg.Seq
+	svc.lifecycleAt = msg.Timestamp
+	s.transitionStatus(svc, StatusRestarting)
+	svc.startTime = time.Time{}
+	svc.cpu = 0
+	svc.memory = 0
 }
 
 // serviceIdentifier extracts the service ID from bus event data
@@ -406,9 +472,14 @@ func (s *store) setServiceStatus(msg bus.Message, status Status) {
 		return
 	}
 
-	if svc, exists := s.services[ident.ServiceID()]; exists {
-		s.transitionStatus(svc, status)
+	svc, exists := s.services[ident.ServiceID()]
+	if !exists || msg.Seq <= svc.lifecycleSeq {
+		return
 	}
+
+	svc.lifecycleSeq = msg.Seq
+	svc.lifecycleAt = msg.Timestamp
+	s.transitionStatus(svc, status)
 }
 
 func (s *store) handleServiceFailed(msg bus.Message) {
@@ -418,10 +489,12 @@ func (s *store) handleServiceFailed(msg bus.Message) {
 	}
 
 	svc, exists := s.services[data.Service.ID]
-	if !exists {
+	if !exists || msg.Seq <= svc.lifecycleSeq {
 		return
 	}
 
+	svc.lifecycleSeq = msg.Seq
+	svc.lifecycleAt = msg.Timestamp
 	s.transitionStatus(svc, StatusFailed)
 	svc.pid = 0
 	svc.cpu = 0
@@ -440,9 +513,14 @@ func (s *store) setWatching(msg bus.Message, value bool) {
 		return
 	}
 
-	if svc, exists := s.services[data.ID]; exists {
-		svc.watching = value
+	svc, exists := s.services[data.ID]
+	if !exists || msg.Seq <= svc.watchSeq {
+		return
 	}
+
+	svc.watchSeq = msg.Seq
+	svc.watchAt = msg.Timestamp
+	svc.watching = value
 }
 
 func (s *store) initServices(tiers []bus.Tier) {

--- a/internal/app/registry/store_test.go
+++ b/internal/app/registry/store_test.go
@@ -191,11 +191,14 @@ func Test_Store_ServiceFailed(t *testing.T) {
 		return found
 	}, testTimeout, testInterval)
 
+	startedAt := time.Now()
+
 	b.Publish(bus.Message{
 		Type: bus.EventServiceStarting,
 		Data: bus.ServiceStarting{
 			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}, Tier: "foundation"},
 			PID:          5678,
+			StartedAt:    startedAt,
 		},
 	})
 
@@ -213,6 +216,7 @@ func Test_Store_ServiceFailed(t *testing.T) {
 	require.True(t, found)
 	assert.Equal(t, 0, svc.PID)
 	assert.True(t, svc.StartTime.IsZero())
+	assert.Equal(t, startedAt, svc.AttemptStartedAt)
 }
 
 func Test_Store_ServiceNotFound(t *testing.T) {
@@ -705,4 +709,125 @@ func Test_Store_ServiceRestarting(t *testing.T) {
 		svc, _ := s.Service("test-id-api")
 		return svc.Status == StatusRestarting
 	}, testTimeout, testInterval)
+}
+
+func Test_Store_ServiceRestarting_ClearsStartTimePreservesAttempt(t *testing.T) {
+	s, b := newTestStore(t, config.DefaultConfig())
+
+	b.Publish(bus.Message{
+		Type: bus.EventProfileResolved,
+		Data: bus.ProfileResolved{
+			Profile: "default",
+			Tiers: []bus.Tier{{Name: "foundation", Services: []bus.Service{
+				{ID: "test-id-api", Name: "api"},
+			}}},
+		},
+	})
+
+	require.Eventually(t, func() bool {
+		_, found := s.Service("test-id-api")
+		return found
+	}, testTimeout, testInterval)
+
+	startedAt := time.Now()
+
+	b.Publish(bus.Message{
+		Type: bus.EventServiceStarting,
+		Data: bus.ServiceStarting{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}, Tier: "foundation"},
+			PID:          1234,
+			StartedAt:    startedAt,
+		},
+	})
+
+	b.Publish(bus.Message{
+		Type: bus.EventServiceReady,
+		Data: bus.ServiceReady{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}, Tier: "foundation"},
+			PID:          1234,
+			StartedAt:    startedAt,
+		},
+	})
+
+	require.Eventually(t, func() bool {
+		svc, _ := s.Service("test-id-api")
+		return svc.Status == StatusRunning
+	}, testTimeout, testInterval)
+
+	svc, _ := s.Service("test-id-api")
+	assert.Equal(t, startedAt, svc.StartTime)
+	assert.Equal(t, startedAt, svc.AttemptStartedAt)
+
+	b.Publish(bus.Message{
+		Type: bus.EventServiceRestarting,
+		Data: bus.ServiceRestarting{ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}, Tier: "foundation"}},
+	})
+
+	require.Eventually(t, func() bool {
+		svc, _ := s.Service("test-id-api")
+		return svc.Status == StatusRestarting
+	}, testTimeout, testInterval)
+
+	svc, _ = s.Service("test-id-api")
+	assert.True(t, svc.StartTime.IsZero(), "StartTime must be cleared during restart")
+	assert.Equal(t, startedAt, svc.AttemptStartedAt, "AttemptStartedAt must be preserved during restart")
+	assert.InDelta(t, 0, svc.CPU, 0)
+	assert.Equal(t, uint64(0), svc.Memory)
+}
+
+func Test_Store_StaleLifecycleEventRejected(t *testing.T) {
+	s, b := newTestStore(t, config.DefaultConfig())
+
+	b.Publish(bus.Message{
+		Type: bus.EventProfileResolved,
+		Data: bus.ProfileResolved{
+			Profile: "default",
+			Tiers: []bus.Tier{{Name: "foundation", Services: []bus.Service{
+				{ID: "test-id-api", Name: "api"},
+			}}},
+		},
+	})
+
+	require.Eventually(t, func() bool {
+		_, found := s.Service("test-id-api")
+		return found
+	}, testTimeout, testInterval)
+
+	b.Publish(bus.Message{
+		Type: bus.EventServiceStarting,
+		Data: bus.ServiceStarting{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}, Tier: "foundation"},
+			PID:          1234,
+		},
+	})
+
+	require.Eventually(t, func() bool {
+		svc, _ := s.Service("test-id-api")
+		return svc.Status == StatusStarting
+	}, testTimeout, testInterval)
+
+	svc, _ := s.Service("test-id-api")
+	startingSeq := svc.LifecycleSeq
+
+	startedAt := time.Now()
+
+	b.Publish(bus.Message{
+		Type: bus.EventServiceReady,
+		Data: bus.ServiceReady{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}, Tier: "foundation"},
+			PID:          1234,
+			StartedAt:    startedAt,
+		},
+	})
+
+	require.Eventually(t, func() bool {
+		svc, _ := s.Service("test-id-api")
+		return svc.Status == StatusRunning
+	}, testTimeout, testInterval)
+
+	svc, _ = s.Service("test-id-api")
+	assert.Greater(t, svc.LifecycleSeq, startingSeq)
+	assert.Equal(t, StatusRunning, svc.Status)
+	assert.Equal(t, 1234, svc.PID)
+	assert.Equal(t, startedAt, svc.StartTime)
 }

--- a/internal/app/runner/service.go
+++ b/internal/app/runner/service.go
@@ -252,8 +252,6 @@ func (s *service) Resume(ctx context.Context, svc bus.Service) {
 
 // doStart creates, starts, and waits for a service to be ready
 func (s *service) doStart(ctx context.Context, tier string, svc bus.Service, cfg *config.Service) (process.Process, error) {
-	startTime := time.Now()
-
 	serviceDir, envFile, err := s.resolvePaths(svc.Name, cfg.Dir)
 	if err != nil {
 		return nil, err
@@ -284,6 +282,8 @@ func (s *service) doStart(ctx context.Context, tier string, svc bus.Service, cfg
 		return nil, fmt.Errorf("%w: %w", errors.ErrFailedToStartCommand, err)
 	}
 
+	startedAt := time.Now()
+
 	s.log.Info().Msgf("Started service '%s' (PID: %d) in directory: %s", svc.Name, cmd.Process.Pid, serviceDir)
 	s.bus.Publish(bus.Message{
 		Type: bus.EventServiceStarting,
@@ -291,6 +291,7 @@ func (s *service) doStart(ctx context.Context, tier string, svc bus.Service, cfg
 			ServiceEvent: bus.ServiceEvent{Service: svc, Tier: tier},
 			PID:          cmd.Process.Pid,
 			Attempt:      1,
+			StartedAt:    startedAt,
 		},
 		Critical: true,
 	})
@@ -308,7 +309,9 @@ func (s *service) doStart(ctx context.Context, tier string, svc bus.Service, cfg
 		Type: bus.EventServiceReady,
 		Data: bus.ServiceReady{
 			ServiceEvent: bus.ServiceEvent{Service: svc, Tier: tier},
-			Duration:     time.Since(startTime),
+			PID:          cmd.Process.Pid,
+			StartedAt:    startedAt,
+			Duration:     time.Since(startedAt),
 		},
 		Critical: true,
 	})

--- a/internal/app/ui/components/constants.go
+++ b/internal/app/ui/components/constants.go
@@ -48,6 +48,16 @@ const (
 	ErrorPadding         = "  "
 )
 
+// Timeline layout constants
+const (
+	DefaultTimelineSlots    = 20
+	MinServiceNameTextWidth = 23
+	MinServiceNameWidth     = IndicatorColumnWidth + MinServiceNameTextWidth
+	MinTimelineWidth        = 10
+	TimelineGap             = 1
+	TimelineBlock           = "▮"
+)
+
 // Unit conversion constants
 const (
 	MBToGB = 1024

--- a/internal/app/ui/components/layout.go
+++ b/internal/app/ui/components/layout.go
@@ -49,6 +49,8 @@ func RenderPanel(opts PanelOptions) string {
 type TableLayout struct {
 	ContentWidth     int
 	ServiceNameWidth int
+	TimelineWidth    int
+	TimelineGapWidth int
 	StatusWidth      int
 	MetricWidth      int
 }
@@ -63,11 +65,31 @@ func ComputeTableLayout(contentWidth int) TableLayout {
 
 	statusWidth := min(contentWidth/5, MaxStatusWidth)
 
-	serviceNameWidth := contentWidth - statusWidth - 4*metricWidth
+	available := contentWidth - statusWidth - 4*metricWidth
+
+	timelineWidth := DefaultTimelineSlots
+
+	switch {
+	case available >= MinServiceNameWidth+timelineWidth+TimelineGap:
+		// Full timeline fits
+	case available >= MinServiceNameWidth+MinTimelineWidth+TimelineGap:
+		timelineWidth = available - MinServiceNameWidth - TimelineGap
+	default:
+		timelineWidth = 0
+	}
+
+	gap := 0
+	if timelineWidth > 0 {
+		gap = TimelineGap
+	}
+
+	serviceNameWidth := available - timelineWidth - gap
 
 	return TableLayout{
 		ContentWidth:     contentWidth,
 		ServiceNameWidth: serviceNameWidth,
+		TimelineWidth:    timelineWidth,
+		TimelineGapWidth: gap,
 		StatusWidth:      statusWidth,
 		MetricWidth:      metricWidth,
 	}

--- a/internal/app/ui/components/layout_test.go
+++ b/internal/app/ui/components/layout_test.go
@@ -16,47 +16,47 @@ func Test_ComputeTableLayout(t *testing.T) {
 		{
 			name:         "negative contentWidth clamped to zero",
 			contentWidth: -5,
-			want:         TableLayout{ContentWidth: 0, ServiceNameWidth: 0, StatusWidth: 0, MetricWidth: 0},
+			want:         TableLayout{ContentWidth: 0, ServiceNameWidth: 0, TimelineWidth: 0, StatusWidth: 0, MetricWidth: 0},
 		},
 		{
 			name:         "zero contentWidth",
 			contentWidth: 0,
-			want:         TableLayout{ContentWidth: 0, ServiceNameWidth: 0, StatusWidth: 0, MetricWidth: 0},
+			want:         TableLayout{ContentWidth: 0, ServiceNameWidth: 0, TimelineWidth: 0, StatusWidth: 0, MetricWidth: 0},
 		},
 		{
-			name:         "narrow terminal (72 cols)",
+			name:         "narrow terminal (72 cols) - timeline hidden",
 			contentWidth: 66,
-			want:         TableLayout{ContentWidth: 66, ServiceNameWidth: 29, StatusWidth: 13, MetricWidth: 6},
+			want:         TableLayout{ContentWidth: 66, ServiceNameWidth: 29, TimelineWidth: 0, StatusWidth: 13, MetricWidth: 6},
 		},
 		{
-			name:         "just below wide breakpoint",
+			name:         "medium terminal (97 cols) - timeline reduced",
 			contentWidth: 97,
-			want:         TableLayout{ContentWidth: 97, ServiceNameWidth: 42, StatusWidth: 19, MetricWidth: 9},
+			want:         TableLayout{ContentWidth: 97, ServiceNameWidth: 25, TimelineWidth: 16, TimelineGapWidth: 1, StatusWidth: 19, MetricWidth: 9},
 		},
 		{
-			name:         "at wide breakpoint (104 cols)",
+			name:         "medium terminal (98 cols) - timeline reduced",
 			contentWidth: 98,
-			want:         TableLayout{ContentWidth: 98, ServiceNameWidth: 43, StatusWidth: 19, MetricWidth: 9},
+			want:         TableLayout{ContentWidth: 98, ServiceNameWidth: 25, TimelineWidth: 17, TimelineGapWidth: 1, StatusWidth: 19, MetricWidth: 9},
 		},
 		{
-			name:         "exact 100 width",
+			name:         "medium terminal (100 cols) - timeline reduced",
 			contentWidth: 100,
-			want:         TableLayout{ContentWidth: 100, ServiceNameWidth: 40, StatusWidth: 20, MetricWidth: 10},
+			want:         TableLayout{ContentWidth: 100, ServiceNameWidth: 25, TimelineWidth: 14, TimelineGapWidth: 1, StatusWidth: 20, MetricWidth: 10},
 		},
 		{
-			name:         "at 114 width (status capped)",
+			name:         "wide terminal (114 cols) - full timeline",
 			contentWidth: 114,
-			want:         TableLayout{ContentWidth: 114, ServiceNameWidth: 50, StatusWidth: 20, MetricWidth: 11},
+			want:         TableLayout{ContentWidth: 114, ServiceNameWidth: 29, TimelineWidth: 20, TimelineGapWidth: 1, StatusWidth: 20, MetricWidth: 11},
 		},
 		{
-			name:         "at 120 width (both capped)",
+			name:         "wide terminal (120 cols) - full timeline",
 			contentWidth: 120,
-			want:         TableLayout{ContentWidth: 120, ServiceNameWidth: 52, StatusWidth: 20, MetricWidth: 12},
+			want:         TableLayout{ContentWidth: 120, ServiceNameWidth: 31, TimelineWidth: 20, TimelineGapWidth: 1, StatusWidth: 20, MetricWidth: 12},
 		},
 		{
 			name:         "ultra-wide terminal (name absorbs extra)",
 			contentWidth: 200,
-			want:         TableLayout{ContentWidth: 200, ServiceNameWidth: 132, StatusWidth: 20, MetricWidth: 12},
+			want:         TableLayout{ContentWidth: 200, ServiceNameWidth: 111, TimelineWidth: 20, TimelineGapWidth: 1, StatusWidth: 20, MetricWidth: 12},
 		},
 	}
 

--- a/internal/app/ui/components/theme.go
+++ b/internal/app/ui/components/theme.go
@@ -40,6 +40,20 @@ type Theme struct {
 	APIDotConnected      lipgloss.Style
 	APIDotDisconnected   lipgloss.Style
 
+	// Timeline strip styles
+	TimelineRunningStyle  lipgloss.Style
+	TimelineStartingStyle lipgloss.Style
+	TimelineFailedStyle   lipgloss.Style
+	TimelineStoppedStyle  lipgloss.Style
+	TimelineEmptyStyle    lipgloss.Style
+
+	// Timeline strip styles (selected row)
+	TimelineSelectedRunningStyle  lipgloss.Style
+	TimelineSelectedStartingStyle lipgloss.Style
+	TimelineSelectedFailedStyle   lipgloss.Style
+	TimelineSelectedStoppedStyle  lipgloss.Style
+	TimelineSelectedEmptyStyle    lipgloss.Style
+
 	// Shared styles (TUI tips + logs banner)
 	HelpKeyStyle  lipgloss.Style
 	HelpDescStyle lipgloss.Style
@@ -93,6 +107,18 @@ func NewTheme(isDark bool) Theme {
 		IndicatorDotStyle:    lipgloss.NewStyle().Foreground(fgStatusRunning),
 		APIDotConnected:      lipgloss.NewStyle().Foreground(ld(lipgloss.Color("#0284c7"), lipgloss.Color("#38bdf8"))),
 		APIDotDisconnected:   lipgloss.NewStyle().Foreground(fgBorder),
+
+		TimelineRunningStyle:  lipgloss.NewStyle().Foreground(fgStatusRunning),
+		TimelineStartingStyle: lipgloss.NewStyle().Foreground(fgStatusWarning),
+		TimelineFailedStyle:   lipgloss.NewStyle().Foreground(fgStatusError),
+		TimelineStoppedStyle:  lipgloss.NewStyle().Foreground(fgBorder),
+		TimelineEmptyStyle:    lipgloss.NewStyle().Foreground(ld(lipgloss.Color("#b8b8b8"), lipgloss.Color("#4a4a4a"))),
+
+		TimelineSelectedRunningStyle:  lipgloss.NewStyle().Foreground(fgStatusRunning).Background(bgSelection),
+		TimelineSelectedStartingStyle: lipgloss.NewStyle().Foreground(fgStatusWarning).Background(bgSelection),
+		TimelineSelectedFailedStyle:   lipgloss.NewStyle().Foreground(fgStatusError).Background(bgSelection),
+		TimelineSelectedStoppedStyle:  lipgloss.NewStyle().Foreground(fgBorder).Background(bgSelection),
+		TimelineSelectedEmptyStyle:    lipgloss.NewStyle().Foreground(ld(lipgloss.Color("#b8b8b8"), lipgloss.Color("#4a4a4a"))).Background(bgSelection),
 	}
 }
 

--- a/internal/app/ui/services/model.go
+++ b/internal/app/ui/services/model.go
@@ -49,18 +49,27 @@ type Tier struct {
 
 // ServiceState represents the state of a service in the UI
 type ServiceState struct {
-	ID        string
-	Name      string
-	Tier      string
-	Status    Status
-	Watching  bool
-	Error     error
-	PID       int
-	CPU       float64
-	MEM       float64
-	StartTime time.Time
-	ReadyTime time.Time
-	Blink     *components.Blink
+	ID               string
+	Name             string
+	Tier             string
+	Status           Status
+	Watching         bool
+	Error            error
+	PID              int
+	CPU              float64
+	MEM              float64
+	StartTime        time.Time
+	AttemptStartedAt time.Time
+	ReadyTime        time.Time
+	LifecycleAt      time.Time
+	LifecycleSeq     uint64
+	BackfilledSeq    uint64
+	StartupSampled   int
+	StartupActive    bool
+	WatchAt          time.Time
+	WatchSeq         uint64
+	Blink            *components.Blink
+	Timeline         *Timeline
 }
 
 // APIListener exposes the bound API server address
@@ -328,7 +337,7 @@ func (m *Model) updateServicesContent() {
 	m.ui.servicesViewport.SetContent(content)
 }
 
-// refreshFromStore updates service state from the store snapshots
+// refreshFromStore reconciles service state from store snapshots
 func (m *Model) refreshFromStore() {
 	snapshots := m.store.Services()
 
@@ -338,18 +347,97 @@ func (m *Model) refreshFromStore() {
 			continue
 		}
 
-		service.Status = snap.Status
-		service.PID = snap.PID
+		m.reconcileLifecycle(service, snap)
+
+		if snap.WatchSeq >= service.WatchSeq {
+			service.WatchSeq = snap.WatchSeq
+			service.WatchAt = snap.WatchAt
+			service.Watching = snap.Watching
+		}
+	}
+}
+
+// reconcileLifecycle applies a store lifecycle snapshot when it is newer or same-event healing
+func (m *Model) reconcileLifecycle(service *ServiceState, snap registry.ServiceSnapshot) {
+	applyLifecycle := snap.LifecycleSeq > service.LifecycleSeq ||
+		(snap.LifecycleSeq == service.LifecycleSeq && snap.Status == service.Status)
+
+	if !applyLifecycle {
+		return
+	}
+
+	stateAdvanced := snap.LifecycleSeq > service.LifecycleSeq || snap.Status != service.Status
+	newProcess := service.AttemptStartedAt != snap.AttemptStartedAt
+
+	if newProcess {
+		service.StartupSampled = 0
+	}
+
+	if snap.Status == registry.StatusStarting {
+		service.StartupActive = true
+	}
+
+	//nolint:exhaustive // only running and terminal states need startup backfill
+	switch snap.Status {
+	case registry.StatusRunning:
+		backfillStartupHistory(service, snap.LifecycleSeq, snap.AttemptStartedAt, snap.LifecycleAt)
+		service.StartupActive = false
+	case registry.StatusFailed, registry.StatusStopped:
+		switch {
+		case !snap.AttemptStartedAt.IsZero() && snap.AttemptStartedAt != service.AttemptStartedAt:
+			backfillStartupHistory(service, snap.LifecycleSeq, snap.AttemptStartedAt, snap.LifecycleAt)
+		case service.StartupActive && !service.AttemptStartedAt.IsZero():
+			backfillStartupHistory(service, snap.LifecycleSeq, service.AttemptStartedAt, snap.LifecycleAt)
+		}
+
+		service.StartupActive = false
+	}
+
+	service.LifecycleSeq = snap.LifecycleSeq
+	service.LifecycleAt = snap.LifecycleAt
+	service.Status = snap.Status
+	service.PID = snap.PID
+	service.AttemptStartedAt = snap.AttemptStartedAt
+
+	if snap.Status == registry.StatusRestarting {
+		service.StartTime = time.Time{}
+	} else {
+		service.StartTime = snap.StartTime
+	}
+
+	switch {
+	case newProcess:
+		service.CPU = 0
+		service.MEM = 0
+	default:
 		service.CPU = snap.CPU
 		service.MEM = float64(snap.Memory) / 1024 / 1024
-		service.StartTime = snap.StartTime
-		service.Watching = snap.Watching
+	}
 
-		switch {
-		case snap.Error != "":
-			service.Error = errors.New(snap.Error)
-		default:
-			service.Error = nil
+	switch {
+	case snap.Error != "":
+		service.Error = errors.New(snap.Error)
+	default:
+		service.Error = nil
+	}
+
+	if stateAdvanced {
+		m.reconcileLifecycleEffects(service, snap.Status)
+	}
+}
+
+// reconcileLifecycleEffects syncs loader and restarting state with the reconciled status
+func (m *Model) reconcileLifecycleEffects(service *ServiceState, status registry.Status) {
+	//nolint:exhaustive // only terminal and restarting states need effect reconciliation
+	switch status {
+	case registry.StatusRunning, registry.StatusFailed:
+		delete(m.state.restarting, service.ID)
+		m.loader.Stop(service.ID)
+	case registry.StatusStopped:
+		if !m.state.restarting[service.ID] {
+			m.loader.Stop(service.ID)
 		}
+	case registry.StatusRestarting:
+		m.state.restarting[service.ID] = true
 	}
 }

--- a/internal/app/ui/services/model_test.go
+++ b/internal/app/ui/services/model_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"charm.land/bubbles/v2/spinner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -270,56 +271,7 @@ func Test_GetSelectedService(t *testing.T) {
 	}
 }
 
-func Test_RefreshFromStore(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	now := time.Now()
-	mockStore := registry.NewMockStore(ctrl)
-	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
-		{
-			ID:        "id-api",
-			Status:    registry.StatusRunning,
-			PID:       1234,
-			CPU:       25.5,
-			Memory:    256 * 1024 * 1024,
-			StartTime: now,
-			Watching:  true,
-		},
-		{
-			ID:     "id-db",
-			Status: registry.StatusFailed,
-			Error:  "connection refused",
-		},
-		{
-			ID:     "id-unknown",
-			Status: registry.StatusRunning,
-		},
-	})
-
-	m := &Model{store: mockStore}
-	m.state.services = map[string]*ServiceState{
-		"id-api": {Name: "api"},
-		"id-db":  {Name: "db"},
-	}
-
-	m.refreshFromStore()
-
-	api := m.state.services["id-api"]
-	assert.Equal(t, registry.StatusRunning, api.Status)
-	assert.Equal(t, 1234, api.PID)
-	assert.InDelta(t, 25.5, api.CPU, 0.01)
-	assert.InDelta(t, 256.0, api.MEM, 0.01)
-	assert.Equal(t, now, api.StartTime)
-	assert.True(t, api.Watching)
-	require.NoError(t, api.Error)
-
-	db := m.state.services["id-db"]
-	assert.Equal(t, registry.StatusFailed, db.Status)
-	assert.EqualError(t, db.Error, "connection refused")
-}
-
-func Test_RefreshFromStore_ClearsError(t *testing.T) {
+func Test_RefreshFromStore_MetricsUpdatedWithMatchingLifecycle(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -327,19 +279,412 @@ func Test_RefreshFromStore_ClearsError(t *testing.T) {
 	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
 		{
 			ID:     "id-api",
-			Status: registry.StatusRunning,
-			Error:  "",
+			CPU:    25.5,
+			Memory: 256 * 1024 * 1024,
+		},
+		{
+			ID:     "id-unknown",
+			CPU:    10.0,
+			Memory: 128 * 1024 * 1024,
 		},
 	})
 
-	m := &Model{store: mockStore}
+	m := &Model{store: mockStore, loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.restarting = map[string]bool{}
 	m.state.services = map[string]*ServiceState{
-		"id-api": {Name: "api", Error: assert.AnError},
+		"id-api": {Name: "api"},
 	}
 
 	m.refreshFromStore()
 
-	require.NoError(t, m.state.services["id-api"].Error)
+	api := m.state.services["id-api"]
+	assert.InDelta(t, 25.5, api.CPU, 0.01)
+	assert.InDelta(t, 256.0, api.MEM, 0.01)
+}
+
+func Test_RefreshFromStore_NewerSnapshotHealsLifecycle(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Second)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:               "id-api",
+			Status:           registry.StatusRunning,
+			PID:              9999,
+			CPU:              50.0,
+			Memory:           512 * 1024 * 1024,
+			StartTime:        t0,
+			AttemptStartedAt: t0,
+			LifecycleAt:      t1,
+			LifecycleSeq:     2,
+			Watching:         true,
+			WatchAt:          t1,
+			WatchSeq:         2,
+		},
+	})
+
+	m := &Model{store: mockStore, loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.restarting = map[string]bool{}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			Name:         "api",
+			Status:       StatusStarting,
+			PID:          1234,
+			LifecycleAt:  t0,
+			LifecycleSeq: 1,
+			WatchAt:      t0,
+			WatchSeq:     1,
+		},
+	}
+
+	m.refreshFromStore()
+
+	api := m.state.services["id-api"]
+	assert.Equal(t, registry.StatusRunning, api.Status)
+	assert.Equal(t, 9999, api.PID)
+	assert.Equal(t, t0, api.StartTime)
+	assert.True(t, api.Watching)
+	assert.Equal(t, t1, api.LifecycleAt)
+	assert.Equal(t, t1, api.WatchAt)
+	assert.InDelta(t, 0.0, api.CPU, 0.01)
+	assert.InDelta(t, 0.0, api.MEM, 0.01)
+}
+
+func Test_RefreshFromStore_OlderSnapshotDoesNotOverwrite(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Second)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:           "id-api",
+			Status:       registry.StatusStarting,
+			PID:          1234,
+			CPU:          50.0,
+			Memory:       512 * 1024 * 1024,
+			StartTime:    t0,
+			LifecycleAt:  t0,
+			LifecycleSeq: 1,
+			Watching:     false,
+			WatchAt:      t0,
+			WatchSeq:     1,
+		},
+	})
+
+	m := &Model{store: mockStore, loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.restarting = map[string]bool{}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			Name:         "api",
+			Status:       StatusFailed,
+			PID:          0,
+			Error:        assert.AnError,
+			LifecycleAt:  t1,
+			LifecycleSeq: 2,
+			Watching:     true,
+			WatchAt:      t1,
+			WatchSeq:     2,
+		},
+	}
+
+	m.refreshFromStore()
+
+	api := m.state.services["id-api"]
+	assert.Equal(t, StatusFailed, api.Status)
+	assert.Equal(t, 0, api.PID)
+	require.EqualError(t, api.Error, assert.AnError.Error())
+	assert.True(t, api.Watching)
+	assert.InDelta(t, 0.0, api.CPU, 0.01)
+	assert.InDelta(t, 0.0, api.MEM, 0.01)
+}
+
+func Test_RefreshFromStore_DroppedWatchEventHealed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Second)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:       "id-api",
+			Watching: true,
+			WatchAt:  t1,
+			WatchSeq: 5,
+		},
+	})
+
+	m := &Model{store: mockStore, loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.restarting = map[string]bool{}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			Name:     "api",
+			WatchAt:  t0,
+			WatchSeq: 3,
+		},
+	}
+
+	m.refreshFromStore()
+
+	assert.True(t, m.state.services["id-api"].Watching)
+	assert.Equal(t, t1, m.state.services["id-api"].WatchAt)
+	assert.Equal(t, uint64(5), m.state.services["id-api"].WatchSeq)
+}
+
+func Test_RefreshFromStore_SameSeqSameStatusHealsFields(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:           "id-api",
+			Status:       registry.StatusRunning,
+			PID:          5678,
+			StartTime:    t0,
+			LifecycleAt:  t0,
+			LifecycleSeq: 10,
+		},
+	})
+
+	m := &Model{store: mockStore, loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.restarting = map[string]bool{}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			Name:         "api",
+			Status:       StatusRunning,
+			PID:          0,
+			StartTime:    time.Time{},
+			Error:        assert.AnError,
+			LifecycleAt:  t0,
+			LifecycleSeq: 10,
+		},
+	}
+
+	m.refreshFromStore()
+
+	api := m.state.services["id-api"]
+	assert.Equal(t, registry.StatusRunning, api.Status)
+	assert.Equal(t, 5678, api.PID)
+	assert.Equal(t, t0, api.StartTime)
+	assert.NoError(t, api.Error)
+}
+
+func Test_RefreshFromStore_SameSeqDifferentStatusDoesNotOverwrite(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:           "id-api",
+			Status:       registry.StatusStarting,
+			PID:          1234,
+			StartTime:    t0,
+			LifecycleAt:  t0,
+			LifecycleSeq: 10,
+		},
+	})
+
+	m := &Model{store: mockStore, loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.restarting = map[string]bool{}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			Name:         "api",
+			Status:       StatusRunning,
+			PID:          5678,
+			LifecycleAt:  t0,
+			LifecycleSeq: 10,
+		},
+	}
+
+	m.refreshFromStore()
+
+	api := m.state.services["id-api"]
+	assert.Equal(t, StatusRunning, api.Status)
+	assert.Equal(t, 5678, api.PID)
+}
+
+func Test_RefreshFromStore_RestartingClearsStartTime(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:               "id-api",
+			Status:           registry.StatusRestarting,
+			PID:              0,
+			StartTime:        time.Time{},
+			AttemptStartedAt: t0,
+			LifecycleAt:      t0.Add(10 * time.Second),
+			LifecycleSeq:     15,
+		},
+	})
+
+	m := &Model{store: mockStore, loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.restarting = map[string]bool{}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			Name:             "api",
+			Status:           StatusRunning,
+			PID:              1234,
+			StartTime:        t0,
+			AttemptStartedAt: t0,
+			LifecycleAt:      t0.Add(5 * time.Second),
+			LifecycleSeq:     10,
+			Timeline:         NewTimeline(20),
+		},
+	}
+
+	m.refreshFromStore()
+
+	api := m.state.services["id-api"]
+	assert.Equal(t, StatusRestarting, api.Status)
+	assert.True(t, api.StartTime.IsZero(), "StartTime must be blank during restart")
+	assert.Equal(t, t0, api.AttemptStartedAt, "AttemptStartedAt must be preserved during restart")
+}
+
+func Test_RefreshFromStore_TerminalRetryPrefersSnapshotAttempt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	oldAttempt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	newAttempt := oldAttempt.Add(10 * time.Second)
+	failedAt := newAttempt.Add(2 * time.Second)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:               "id-api",
+			Status:           registry.StatusFailed,
+			AttemptStartedAt: newAttempt,
+			LifecycleAt:      failedAt,
+			LifecycleSeq:     20,
+		},
+	})
+
+	tl := NewTimeline(20)
+	m := &Model{store: mockStore, loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.restarting = map[string]bool{}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			Name:             "api",
+			Status:           StatusStarting,
+			StartupActive:    true,
+			AttemptStartedAt: oldAttempt,
+			LifecycleSeq:     10,
+			Timeline:         tl,
+		},
+	}
+
+	m.refreshFromStore()
+
+	assert.Equal(t, 2, tl.Count(), "backfill should use 2s snapshot attempt, not stale UI attempt")
+
+	slots := tl.Slots()
+	for i := range 2 {
+		assert.Equal(t, SlotStarting, slots[i])
+	}
+}
+
+func Test_RefreshFromStore_UnchangedSnapshotKeepsOptimisticLoader(t *testing.T) {
+	tests := []struct {
+		name   string
+		status registry.Status
+	}{
+		{
+			name:   "stopped service with start loader",
+			status: registry.StatusStopped,
+		},
+		{
+			name:   "running service with stop loader",
+			status: registry.StatusRunning,
+		},
+		{
+			name:   "failed service with restart loader",
+			status: registry.StatusFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockStore := registry.NewMockStore(ctrl)
+			mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+				{
+					ID:           "id-api",
+					Status:       tt.status,
+					LifecycleSeq: 5,
+				},
+			})
+
+			loader := &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}
+			m := &Model{store: mockStore, loader: loader}
+			m.state.restarting = map[string]bool{}
+			m.state.services = map[string]*ServiceState{
+				"id-api": {
+					Name:         "api",
+					Status:       tt.status,
+					LifecycleSeq: 5,
+				},
+			}
+
+			loader.Start("id-api", "working…")
+
+			m.refreshFromStore()
+
+			assert.True(t, loader.Active, "optimistic loader must survive unchanged snapshot")
+		})
+	}
+}
+
+func Test_RefreshFromStore_NewerSnapshotStopsLoader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:           "id-api",
+			Status:       registry.StatusRunning,
+			LifecycleSeq: 10,
+		},
+	})
+
+	loader := &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}
+	m := &Model{store: mockStore, loader: loader}
+	m.state.restarting = map[string]bool{}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:           "id-api",
+			Name:         "api",
+			Status:       StatusStarting,
+			LifecycleSeq: 5,
+		},
+	}
+
+	loader.Start("id-api", "starting…")
+
+	m.refreshFromStore()
+
+	assert.False(t, loader.Active, "newer lifecycle snapshot must stop loader")
 }
 
 func Test_CalculateScrollOffset(t *testing.T) {

--- a/internal/app/ui/services/timeline.go
+++ b/internal/app/ui/services/timeline.go
@@ -69,7 +69,7 @@ func (t *Timeline) Slots() []TimelineSlot {
 	return result
 }
 
-// Backfill appends n samples of the given slot, capped by remaining capacity
+// Backfill appends n samples of the given slot, capped by timeline capacity
 func (t *Timeline) Backfill(slot TimelineSlot, n int) {
 	for range min(n, t.capacity) {
 		t.Append(slot)

--- a/internal/app/ui/services/timeline.go
+++ b/internal/app/ui/services/timeline.go
@@ -1,0 +1,135 @@
+package services
+
+import "time"
+
+// TimelineSlot represents the state of a single timeline sample
+type TimelineSlot uint8
+
+// Timeline slot constants
+const (
+	SlotEmpty    TimelineSlot = iota // No observation recorded
+	SlotRunning                      // Service is running
+	SlotStarting                     // Service is starting, restarting, or stopping
+	SlotFailed                       // Service has failed
+	SlotStopped                      // Service is stopped
+)
+
+// Timeline is a fixed-capacity ring buffer that records per-second service state samples
+type Timeline struct {
+	slots    []TimelineSlot
+	capacity int
+	index    int
+	count    int
+}
+
+// NewTimeline creates a new Timeline with the given capacity
+func NewTimeline(capacity int) *Timeline {
+	if capacity < 1 {
+		capacity = 1
+	}
+
+	return &Timeline{
+		slots:    make([]TimelineSlot, capacity),
+		capacity: capacity,
+	}
+}
+
+// Append adds a sample to the timeline, dropping the oldest when full
+func (t *Timeline) Append(slot TimelineSlot) {
+	t.slots[t.index] = slot
+	t.index = (t.index + 1) % t.capacity
+
+	if t.count < t.capacity {
+		t.count++
+	}
+}
+
+// Count returns the number of observed samples
+func (t *Timeline) Count() int {
+	return t.count
+}
+
+// Slots returns the current window in chronological order, padded with SlotEmpty on the right for unobserved positions
+func (t *Timeline) Slots() []TimelineSlot {
+	result := make([]TimelineSlot, t.capacity)
+
+	if t.count == 0 {
+		return result
+	}
+
+	start := 0
+	if t.count == t.capacity {
+		start = t.index
+	}
+
+	for i := range t.count {
+		result[i] = t.slots[(start+i)%t.capacity]
+	}
+
+	return result
+}
+
+// Backfill appends n samples of the given slot, capped by remaining capacity
+func (t *Timeline) Backfill(slot TimelineSlot, n int) {
+	for range min(n, t.capacity) {
+		t.Append(slot)
+	}
+}
+
+// backfillStartupHistory seeds missing amber slots for a service that became ready
+func backfillStartupHistory(service *ServiceState, lifecycleSeq uint64, startedAt time.Time, readyAt time.Time) {
+	if service.Timeline == nil || service.BackfilledSeq >= lifecycleSeq {
+		return
+	}
+
+	if startedAt.IsZero() || !readyAt.After(startedAt) {
+		return
+	}
+
+	service.BackfilledSeq = lifecycleSeq
+
+	desired := max(1, int(readyAt.Sub(startedAt).Seconds()))
+	missing := max(0, desired-service.StartupSampled)
+
+	service.Timeline.Backfill(SlotStarting, missing)
+	service.StartupSampled = max(service.StartupSampled, desired)
+}
+
+// sampleTimelines appends the current status of each service to its timeline
+func (m *Model) sampleTimelines() {
+	for _, service := range m.state.services {
+		if service.Timeline == nil {
+			continue
+		}
+
+		if service.StartTime.IsZero() && service.Timeline.Count() == 0 &&
+			service.Status != StatusFailed &&
+			service.Status != StatusStopped &&
+			service.Status != StatusRestarting {
+			continue
+		}
+
+		slot := StatusToSlot(service.Status)
+		service.Timeline.Append(slot)
+
+		if slot == SlotStarting {
+			service.StartupSampled++
+		}
+	}
+}
+
+// StatusToSlot maps a service Status to the corresponding TimelineSlot
+func StatusToSlot(status Status) TimelineSlot {
+	switch status {
+	case StatusRunning:
+		return SlotRunning
+	case StatusStarting, StatusRestarting, StatusStopping:
+		return SlotStarting
+	case StatusFailed:
+		return SlotFailed
+	case StatusStopped:
+		return SlotStopped
+	default:
+		return SlotEmpty
+	}
+}

--- a/internal/app/ui/services/timeline_test.go
+++ b/internal/app/ui/services/timeline_test.go
@@ -238,6 +238,48 @@ func Test_Timeline_Backfill(t *testing.T) {
 	}
 }
 
+func Test_Timeline_Backfill_EvictsOldSamplesOnFullStrip(t *testing.T) {
+	tl := NewTimeline(5)
+	for range 5 {
+		tl.Append(SlotRunning)
+	}
+
+	tl.Backfill(SlotStarting, 2)
+
+	assert.Equal(t, 5, tl.Count())
+
+	slots := tl.Slots()
+	assert.Equal(t, SlotRunning, slots[0])
+	assert.Equal(t, SlotRunning, slots[1])
+	assert.Equal(t, SlotRunning, slots[2])
+	assert.Equal(t, SlotStarting, slots[3])
+	assert.Equal(t, SlotStarting, slots[4])
+}
+
+func Test_BackfillStartupHistory_FullStrip(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tl := NewTimeline(5)
+	for range 5 {
+		tl.Append(SlotRunning)
+	}
+
+	svc := &ServiceState{
+		Timeline: tl,
+	}
+
+	backfillStartupHistory(svc, 1, t0, t0.Add(3*time.Second))
+
+	assert.Equal(t, 5, tl.Count())
+
+	slots := tl.Slots()
+	assert.Equal(t, SlotRunning, slots[0])
+	assert.Equal(t, SlotRunning, slots[1])
+	assert.Equal(t, SlotStarting, slots[2])
+	assert.Equal(t, SlotStarting, slots[3])
+	assert.Equal(t, SlotStarting, slots[4])
+}
+
 func Test_BackfillStartupHistory(t *testing.T) {
 	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 

--- a/internal/app/ui/services/timeline_test.go
+++ b/internal/app/ui/services/timeline_test.go
@@ -1,0 +1,332 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewTimeline(t *testing.T) {
+	tests := []struct {
+		name         string
+		capacity     int
+		wantCapacity int
+	}{
+		{
+			name:         "normal capacity",
+			capacity:     20,
+			wantCapacity: 20,
+		},
+		{
+			name:         "zero capacity clamped to 1",
+			capacity:     0,
+			wantCapacity: 1,
+		},
+		{
+			name:         "negative capacity clamped to 1",
+			capacity:     -5,
+			wantCapacity: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tl := NewTimeline(tt.capacity)
+
+			assert.Equal(t, tt.wantCapacity, tl.capacity)
+			assert.Equal(t, 0, tl.count)
+			assert.Equal(t, 0, tl.index)
+			assert.Len(t, tl.slots, tt.wantCapacity)
+		})
+	}
+}
+
+func Test_Timeline_Append(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity int
+		appends  []TimelineSlot
+		want     []TimelineSlot
+	}{
+		{
+			name:     "empty timeline returns all SlotEmpty",
+			capacity: 5,
+			appends:  nil,
+			want:     []TimelineSlot{SlotEmpty, SlotEmpty, SlotEmpty, SlotEmpty, SlotEmpty},
+		},
+		{
+			name:     "single append pads right with SlotEmpty",
+			capacity: 5,
+			appends:  []TimelineSlot{SlotRunning},
+			want:     []TimelineSlot{SlotRunning, SlotEmpty, SlotEmpty, SlotEmpty, SlotEmpty},
+		},
+		{
+			name:     "partial fill",
+			capacity: 5,
+			appends:  []TimelineSlot{SlotStarting, SlotRunning, SlotRunning},
+			want:     []TimelineSlot{SlotStarting, SlotRunning, SlotRunning, SlotEmpty, SlotEmpty},
+		},
+		{
+			name:     "full capacity",
+			capacity: 5,
+			appends:  []TimelineSlot{SlotStarting, SlotRunning, SlotRunning, SlotRunning, SlotFailed},
+			want:     []TimelineSlot{SlotStarting, SlotRunning, SlotRunning, SlotRunning, SlotFailed},
+		},
+		{
+			name:     "ring wraps and drops oldest",
+			capacity: 5,
+			appends:  []TimelineSlot{SlotStarting, SlotRunning, SlotRunning, SlotRunning, SlotFailed, SlotStopped},
+			want:     []TimelineSlot{SlotRunning, SlotRunning, SlotRunning, SlotFailed, SlotStopped},
+		},
+		{
+			name:     "multiple wraps maintain order",
+			capacity: 3,
+			appends:  []TimelineSlot{SlotStarting, SlotRunning, SlotFailed, SlotStopped, SlotStarting, SlotRunning, SlotRunning},
+			want:     []TimelineSlot{SlotStarting, SlotRunning, SlotRunning},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tl := NewTimeline(tt.capacity)
+
+			for _, s := range tt.appends {
+				tl.Append(s)
+			}
+
+			assert.Equal(t, tt.want, tl.Slots())
+		})
+	}
+}
+
+func Test_Timeline_Count(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity int
+		appends  int
+		want     int
+	}{
+		{
+			name:     "empty timeline",
+			capacity: 5,
+			appends:  0,
+			want:     0,
+		},
+		{
+			name:     "partial fill",
+			capacity: 5,
+			appends:  3,
+			want:     3,
+		},
+		{
+			name:     "full capacity",
+			capacity: 5,
+			appends:  5,
+			want:     5,
+		},
+		{
+			name:     "past capacity caps at capacity",
+			capacity: 5,
+			appends:  8,
+			want:     5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tl := NewTimeline(tt.capacity)
+
+			for range tt.appends {
+				tl.Append(SlotRunning)
+			}
+
+			assert.Equal(t, tt.want, tl.Count())
+		})
+	}
+}
+
+func Test_StatusToSlot(t *testing.T) {
+	tests := []struct {
+		name   string
+		status Status
+		want   TimelineSlot
+	}{
+		{
+			name:   "running maps to SlotRunning",
+			status: StatusRunning,
+			want:   SlotRunning,
+		},
+		{
+			name:   "starting maps to SlotStarting",
+			status: StatusStarting,
+			want:   SlotStarting,
+		},
+		{
+			name:   "restarting maps to SlotStarting",
+			status: StatusRestarting,
+			want:   SlotStarting,
+		},
+		{
+			name:   "stopping maps to SlotStarting",
+			status: StatusStopping,
+			want:   SlotStarting,
+		},
+		{
+			name:   "failed maps to SlotFailed",
+			status: StatusFailed,
+			want:   SlotFailed,
+		},
+		{
+			name:   "stopped maps to SlotStopped",
+			status: StatusStopped,
+			want:   SlotStopped,
+		},
+		{
+			name:   "unknown status maps to SlotEmpty",
+			status: "unknown",
+			want:   SlotEmpty,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, StatusToSlot(tt.status))
+		})
+	}
+}
+
+func Test_Timeline_Backfill(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity int
+		n        int
+		wantLen  int
+	}{
+		{
+			name:     "backfill within capacity",
+			capacity: 20,
+			n:        5,
+			wantLen:  5,
+		},
+		{
+			name:     "backfill capped at capacity",
+			capacity: 3,
+			n:        10,
+			wantLen:  3,
+		},
+		{
+			name:     "backfill zero samples",
+			capacity: 20,
+			n:        0,
+			wantLen:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tl := NewTimeline(tt.capacity)
+			tl.Backfill(SlotStarting, tt.n)
+
+			assert.Equal(t, tt.wantLen, tl.Count())
+
+			slots := tl.Slots()
+			for i := range tt.wantLen {
+				assert.Equal(t, SlotStarting, slots[i])
+			}
+		})
+	}
+}
+
+func Test_BackfillStartupHistory(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name           string
+		startupSampled int
+		startedAt      time.Time
+		readyAt        time.Time
+		wantAdded      int
+	}{
+		{
+			name:           "multi-second with some amber already sampled",
+			startupSampled: 2,
+			startedAt:      t0,
+			readyAt:        t0.Add(5 * time.Second),
+			wantAdded:      3,
+		},
+		{
+			name:           "sub-second with no amber sampled",
+			startupSampled: 0,
+			startedAt:      t0,
+			readyAt:        t0.Add(200 * time.Millisecond),
+			wantAdded:      1,
+		},
+		{
+			name:           "sub-second with amber already sampled",
+			startupSampled: 1,
+			startedAt:      t0,
+			readyAt:        t0.Add(200 * time.Millisecond),
+			wantAdded:      0,
+		},
+		{
+			name:           "exact match already sampled",
+			startupSampled: 3,
+			startedAt:      t0,
+			readyAt:        t0.Add(3 * time.Second),
+			wantAdded:      0,
+		},
+		{
+			name:           "zero duration",
+			startupSampled: 0,
+			startedAt:      t0,
+			readyAt:        t0,
+			wantAdded:      0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tl := NewTimeline(20)
+			svc := &ServiceState{
+				Timeline:       tl,
+				StartupSampled: tt.startupSampled,
+			}
+
+			backfillStartupHistory(svc, 1, tt.startedAt, tt.readyAt)
+
+			assert.Equal(t, tt.wantAdded, tl.Count())
+		})
+	}
+}
+
+func Test_SampleTimelines_RestartingWithZeroStartTime(t *testing.T) {
+	tl := NewTimeline(20)
+	m := &Model{}
+	m.state.services = map[string]*ServiceState{
+		"svc": {
+			Status:   StatusRestarting,
+			Timeline: tl,
+		},
+	}
+
+	m.sampleTimelines()
+
+	assert.Equal(t, 1, tl.Count())
+	assert.Equal(t, SlotStarting, tl.Slots()[0])
+}
+
+func Test_SampleTimelines_StartingWithZeroStartTimeSkipped(t *testing.T) {
+	tl := NewTimeline(20)
+	m := &Model{}
+	m.state.services = map[string]*ServiceState{
+		"svc": {
+			Status:   StatusStarting,
+			Timeline: tl,
+		},
+	}
+
+	m.sampleTimelines()
+
+	assert.Equal(t, 0, tl.Count())
+}

--- a/internal/app/ui/services/update.go
+++ b/internal/app/ui/services/update.go
@@ -699,13 +699,16 @@ func (m Model) handleWatchStarted(msg bus.Message) Model {
 		return m
 	}
 
-	if service, exists := m.state.services[data.ID]; exists {
-		if msg.Seq > service.WatchSeq {
-			service.WatchSeq = msg.Seq
-			service.WatchAt = msg.Timestamp
-			service.Watching = true
-		}
+	service, exists := m.state.services[data.ID]
+	if !exists || msg.Seq <= service.WatchSeq {
+		m.updateServicesContent()
+
+		return m
 	}
+
+	service.WatchSeq = msg.Seq
+	service.WatchAt = msg.Timestamp
+	service.Watching = true
 
 	m.updateServicesContent()
 
@@ -719,13 +722,16 @@ func (m Model) handleWatchStopped(msg bus.Message) Model {
 		return m
 	}
 
-	if service, exists := m.state.services[data.ID]; exists {
-		if msg.Seq > service.WatchSeq {
-			service.WatchSeq = msg.Seq
-			service.WatchAt = msg.Timestamp
-			service.Watching = false
-		}
+	service, exists := m.state.services[data.ID]
+	if !exists || msg.Seq <= service.WatchSeq {
+		m.updateServicesContent()
+
+		return m
 	}
+
+	service.WatchSeq = msg.Seq
+	service.WatchAt = msg.Timestamp
+	service.Watching = false
 
 	m.updateServicesContent()
 

--- a/internal/app/ui/services/update.go
+++ b/internal/app/ui/services/update.go
@@ -90,6 +90,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.state.now.IsZero() || m.ui.tickCounter%components.UITicksPerSecond == 0 {
 			m.state.now = time.Now()
 			m.refreshFromStore()
+			m.sampleTimelines()
 			m.updateAPIHealth()
 			cmds = append(cmds, m.sampleAppStatsCmd())
 		}
@@ -457,11 +458,12 @@ func (m Model) handleProfileResolved(msg bus.Message) Model {
 
 		for _, ref := range tier.Services {
 			m.state.services[ref.ID] = &ServiceState{
-				ID:     ref.ID,
-				Name:   ref.Name,
-				Tier:   tier.Name,
-				Status: StatusStarting,
-				Blink:  components.NewBlink(),
+				ID:       ref.ID,
+				Name:     ref.Name,
+				Tier:     tier.Name,
+				Status:   StatusStarting,
+				Blink:    components.NewBlink(),
+				Timeline: NewTimeline(components.DefaultTimelineSlots),
 			}
 		}
 	}
@@ -523,18 +525,30 @@ func (m Model) handleServiceStarting(msg bus.Message) Model {
 		return m
 	}
 
-	if service, exists := m.state.services[data.Service.ID]; exists {
-		service.Status = StatusStarting
-		service.Tier = data.Tier
-		service.PID = data.PID
-		service.StartTime = msg.Timestamp
-		service.Error = nil
+	service, exists := m.state.services[data.Service.ID]
+	if !exists || msg.Seq < service.LifecycleSeq {
+		return m
+	}
 
-		delete(m.state.restarting, data.Service.ID)
+	if service.AttemptStartedAt != data.StartedAt {
+		service.StartupSampled = 0
+		service.BackfilledSeq = 0
+	}
 
-		if !m.loader.Has(data.Service.ID) {
-			m.loader.Start(data.Service.ID, fmt.Sprintf("starting %s…", data.Service.Name))
-		}
+	service.LifecycleSeq = msg.Seq
+	service.LifecycleAt = msg.Timestamp
+	service.Status = StatusStarting
+	service.StartupActive = true
+	service.Tier = data.Tier
+	service.PID = data.PID
+	service.StartTime = data.StartedAt
+	service.AttemptStartedAt = data.StartedAt
+	service.Error = nil
+
+	delete(m.state.restarting, data.Service.ID)
+
+	if !m.loader.Has(data.Service.ID) {
+		m.loader.Start(data.Service.ID, fmt.Sprintf("starting %s…", data.Service.Name))
 	}
 
 	return m
@@ -547,12 +561,38 @@ func (m Model) handleServiceReady(msg bus.Message) Model {
 		return m
 	}
 
-	if service, exists := m.state.services[data.Service.ID]; exists {
-		service.Status = StatusRunning
-		service.ReadyTime = msg.Timestamp
-
-		m.loader.Stop(data.Service.ID)
+	service, exists := m.state.services[data.Service.ID]
+	if !exists || msg.Seq < service.LifecycleSeq {
+		return m
 	}
+
+	newProcess := service.AttemptStartedAt != data.StartedAt
+
+	if newProcess {
+		service.StartupActive = true
+		service.StartupSampled = 0
+		service.BackfilledSeq = 0
+		service.CPU = 0
+		service.MEM = 0
+	}
+
+	if service.StartupActive {
+		backfillStartupHistory(service, msg.Seq, data.StartedAt, msg.Timestamp)
+	}
+
+	service.LifecycleSeq = msg.Seq
+	service.LifecycleAt = msg.Timestamp
+	service.Status = StatusRunning
+	service.StartupActive = false
+	service.Tier = data.Tier
+	service.PID = data.PID
+	service.StartTime = data.StartedAt
+	service.AttemptStartedAt = data.StartedAt
+	service.ReadyTime = msg.Timestamp
+	service.Error = nil
+
+	delete(m.state.restarting, data.Service.ID)
+	m.loader.Stop(data.Service.ID)
 
 	return m
 }
@@ -564,13 +604,18 @@ func (m Model) handleServiceFailed(msg bus.Message) Model {
 		return m
 	}
 
-	if service, exists := m.state.services[data.Service.ID]; exists {
-		service.Status = StatusFailed
-		service.Error = data.Error
-
-		m.loader.Stop(data.Service.ID)
-		delete(m.state.restarting, data.Service.ID)
+	service, exists := m.state.services[data.Service.ID]
+	if !exists || msg.Seq < service.LifecycleSeq {
+		return m
 	}
+
+	service.LifecycleSeq = msg.Seq
+	service.LifecycleAt = msg.Timestamp
+	service.Status = StatusFailed
+	service.Error = data.Error
+
+	m.loader.Stop(data.Service.ID)
+	delete(m.state.restarting, data.Service.ID)
 
 	return m
 }
@@ -582,12 +627,17 @@ func (m Model) handleServiceStopping(msg bus.Message) Model {
 		return m
 	}
 
-	if service, exists := m.state.services[data.Service.ID]; exists {
-		service.Status = StatusStopping
+	service, exists := m.state.services[data.Service.ID]
+	if !exists || msg.Seq < service.LifecycleSeq {
+		return m
+	}
 
-		if !m.loader.Has(data.Service.ID) {
-			m.loader.Start(data.Service.ID, fmt.Sprintf("stopping %s…", data.Service.Name))
-		}
+	service.LifecycleSeq = msg.Seq
+	service.LifecycleAt = msg.Timestamp
+	service.Status = StatusStopping
+
+	if !m.loader.Has(data.Service.ID) {
+		m.loader.Start(data.Service.ID, fmt.Sprintf("stopping %s…", data.Service.Name))
 	}
 
 	return m
@@ -600,11 +650,17 @@ func (m Model) handleServiceRestarting(msg bus.Message) Model {
 		return m
 	}
 
-	if service, exists := m.state.services[data.Service.ID]; exists {
-		service.Status = StatusRestarting
-		m.state.restarting[data.Service.ID] = true
-		m.loader.Start(data.Service.ID, fmt.Sprintf("restarting %s…", data.Service.Name))
+	service, exists := m.state.services[data.Service.ID]
+	if !exists || msg.Seq < service.LifecycleSeq {
+		return m
 	}
+
+	service.LifecycleSeq = msg.Seq
+	service.LifecycleAt = msg.Timestamp
+	service.Status = StatusRestarting
+	service.StartTime = time.Time{}
+	m.state.restarting[data.Service.ID] = true
+	m.loader.Start(data.Service.ID, fmt.Sprintf("restarting %s…", data.Service.Name))
 
 	return m
 }
@@ -621,6 +677,12 @@ func (m Model) handleServiceStopped(msg bus.Message) Model {
 		return m
 	}
 
+	if msg.Seq < service.LifecycleSeq {
+		return m
+	}
+
+	service.LifecycleSeq = msg.Seq
+	service.LifecycleAt = msg.Timestamp
 	service.Status = StatusStopped
 
 	if !m.state.restarting[data.Service.ID] {
@@ -638,7 +700,11 @@ func (m Model) handleWatchStarted(msg bus.Message) Model {
 	}
 
 	if service, exists := m.state.services[data.ID]; exists {
-		service.Watching = true
+		if msg.Seq > service.WatchSeq {
+			service.WatchSeq = msg.Seq
+			service.WatchAt = msg.Timestamp
+			service.Watching = true
+		}
 	}
 
 	m.updateServicesContent()
@@ -654,7 +720,11 @@ func (m Model) handleWatchStopped(msg bus.Message) Model {
 	}
 
 	if service, exists := m.state.services[data.ID]; exists {
-		service.Watching = false
+		if msg.Seq > service.WatchSeq {
+			service.WatchSeq = msg.Seq
+			service.WatchAt = msg.Timestamp
+			service.Watching = false
+		}
 	}
 
 	m.updateServicesContent()

--- a/internal/app/ui/services/update_test.go
+++ b/internal/app/ui/services/update_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"fuku/internal/app/bus"
+	"fuku/internal/app/registry"
 	"fuku/internal/app/ui/components"
 	"fuku/internal/config/logger"
 )
@@ -323,10 +324,12 @@ func Test_HandleServiceStarting(t *testing.T) {
 	m.state.restarting = make(map[string]bool)
 
 	now := time.Now()
+	startedAt := now.Add(-time.Second)
 	event := bus.Message{
 		Timestamp: now,
+		Seq:       1,
 		Type:      bus.EventServiceStarting,
-		Data:      bus.ServiceStarting{ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}, Tier: "tier1"}, PID: 1234},
+		Data:      bus.ServiceStarting{ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}, Tier: "tier1"}, PID: 1234, StartedAt: startedAt},
 	}
 
 	result := m.handleServiceStarting(event)
@@ -334,7 +337,7 @@ func Test_HandleServiceStarting(t *testing.T) {
 	assert.Equal(t, StatusStarting, result.state.services["test-id-api"].Status)
 	assert.Equal(t, "tier1", result.state.services["test-id-api"].Tier)
 	assert.Equal(t, 1234, result.state.services["test-id-api"].PID)
-	assert.Equal(t, now, result.state.services["test-id-api"].StartTime)
+	assert.Equal(t, startedAt, result.state.services["test-id-api"].StartTime)
 	require.NoError(t, result.state.services["test-id-api"].Error)
 	assert.True(t, result.loader.Has("test-id-api"))
 	assert.True(t, result.loader.Active)
@@ -364,6 +367,7 @@ func Test_HandleServiceStarting_ClearsRestartingFlag(t *testing.T) {
 
 	event := bus.Message{
 		Timestamp: time.Now(),
+		Seq:       1,
 		Type:      bus.EventServiceStarting,
 		Data:      bus.ServiceStarting{ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}, Tier: "tier1"}, PID: 5678},
 	}
@@ -389,6 +393,7 @@ func Test_HandleServiceStarting_DoesNotDuplicateLoader(t *testing.T) {
 
 	event := bus.Message{
 		Timestamp: time.Now(),
+		Seq:       1,
 		Type:      bus.EventServiceStarting,
 		Data:      bus.ServiceStarting{ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}, Tier: "tier1"}, PID: 1234},
 	}
@@ -420,16 +425,27 @@ func Test_HandleServiceReady(t *testing.T) {
 	m.state.services = map[string]*ServiceState{"test-id-api": service}
 
 	now := time.Now()
+	started := now.Add(-2 * time.Second)
 	event := bus.Message{
 		Timestamp: now,
+		Seq:       1,
 		Type:      bus.EventServiceReady,
-		Data:      bus.ServiceReady{ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}}},
+		Data: bus.ServiceReady{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}, Tier: "platform"},
+			PID:          5678,
+			StartedAt:    started,
+		},
 	}
 
 	result := m.handleServiceReady(event)
 
-	assert.Equal(t, StatusRunning, result.state.services["test-id-api"].Status)
-	assert.Equal(t, now, result.state.services["test-id-api"].ReadyTime)
+	svc := result.state.services["test-id-api"]
+	assert.Equal(t, StatusRunning, svc.Status)
+	assert.Equal(t, "platform", svc.Tier)
+	assert.Equal(t, 5678, svc.PID)
+	assert.Equal(t, started, svc.StartTime)
+	assert.Equal(t, now, svc.ReadyTime)
+	require.NoError(t, svc.Error)
 	assert.False(t, result.loader.Active)
 	assert.False(t, result.loader.Has("test-id-api"))
 }
@@ -460,6 +476,7 @@ func Test_HandleServiceFailed(t *testing.T) {
 
 	testErr := assert.AnError
 	event := bus.Message{
+		Seq:  1,
 		Type: bus.EventServiceFailed,
 		Data: bus.ServiceFailed{ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}}, Error: testErr},
 	}
@@ -497,6 +514,7 @@ func Test_HandleServiceFailed_ClearsRestartingFlag(t *testing.T) {
 	m.state.restarting = map[string]bool{"api": true}
 
 	event := bus.Message{
+		Seq:  1,
 		Type: bus.EventServiceFailed,
 		Data: bus.ServiceFailed{ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}}, Error: assert.AnError},
 	}
@@ -518,6 +536,7 @@ func Test_HandleServiceStopping(t *testing.T) {
 	m.state.services = map[string]*ServiceState{"test-id-api": service}
 
 	event := bus.Message{
+		Seq:  1,
 		Type: bus.EventServiceStopping,
 		Data: bus.ServiceStopping{ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}}},
 	}
@@ -552,6 +571,7 @@ func Test_HandleServiceStopping_DoesNotDuplicateLoader(t *testing.T) {
 	m.state.services = map[string]*ServiceState{"test-id-api": service}
 
 	event := bus.Message{
+		Seq:  1,
 		Type: bus.EventServiceStopping,
 		Data: bus.ServiceStopping{ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}}},
 	}
@@ -582,6 +602,7 @@ func Test_HandleServiceRestarting(t *testing.T) {
 	m.state.restarting = make(map[string]bool)
 
 	event := bus.Message{
+		Seq:  1,
 		Type: bus.EventServiceRestarting,
 		Data: bus.ServiceRestarting{ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}}},
 	}
@@ -643,6 +664,7 @@ func Test_HandleServiceStopped(t *testing.T) {
 			m.state.restarting = map[string]bool{"test-id-api": tt.restarting}
 
 			event := bus.Message{
+				Seq:  1,
 				Type: bus.EventServiceStopped,
 				Data: bus.ServiceStopped{ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "test-id-api", Name: "api"}}},
 			}
@@ -687,6 +709,7 @@ func Test_HandleWatchStarted(t *testing.T) {
 	m.state.services = map[string]*ServiceState{"test-id-api": service}
 
 	event := bus.Message{
+		Seq:  1,
 		Type: bus.EventWatchStarted,
 		Data: bus.Service{ID: "test-id-api", Name: "api"},
 	}
@@ -727,6 +750,7 @@ func Test_HandleWatchStopped(t *testing.T) {
 	m.state.services = map[string]*ServiceState{"test-id-api": service}
 
 	event := bus.Message{
+		Seq:  1,
 		Type: bus.EventWatchStopped,
 		Data: bus.Service{ID: "test-id-api", Name: "api"},
 	}
@@ -1810,6 +1834,1170 @@ func Test_CalculateScrollOffset_WithFilter(t *testing.T) {
 	offset := m.calculateScrollOffset()
 
 	assert.Equal(t, 3, offset)
+}
+
+func Test_HandleProfileResolved_CreatesTimelines(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLog := logger.NewMockLogger(ctrl)
+	noopLogger := zerolog.New(io.Discard)
+	mockLog.EXPECT().Debug().Return(noopLogger.Debug()).AnyTimes()
+	mockLog.EXPECT().Info().Return(noopLogger.Info()).AnyTimes()
+	mockLog.EXPECT().Warn().Return(noopLogger.Warn()).AnyTimes()
+	mockLog.EXPECT().Error().Return(noopLogger.Error()).AnyTimes()
+
+	m := Model{log: mockLog, loader: NewLoader()}
+	m.state.services = make(map[string]*ServiceState)
+	m.state.restarting = make(map[string]bool)
+	m.state.tiers = make([]Tier, 0)
+
+	event := bus.Message{
+		Type: bus.EventProfileResolved,
+		Data: bus.ProfileResolved{
+			Profile: "dev",
+			Tiers: []bus.Tier{
+				{Name: "tier1", Services: []bus.Service{{ID: "test-id-db", Name: "db"}, {ID: "test-id-api", Name: "api"}}},
+			},
+		},
+	}
+
+	result := m.handleProfileResolved(event)
+
+	for _, id := range []string{"test-id-db", "test-id-api"} {
+		svc := result.state.services[id]
+		require.NotNil(t, svc.Timeline, "service %s should have a timeline", id)
+		assert.Equal(t, components.DefaultTimelineSlots, svc.Timeline.capacity, "timeline capacity should be %d", components.DefaultTimelineSlots)
+		assert.Equal(t, 0, svc.Timeline.count, "timeline should start empty")
+	}
+}
+
+func Test_HandleProfileResolved_FreshTimelinesOnReload(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLog := logger.NewMockLogger(ctrl)
+	noopLogger := zerolog.New(io.Discard)
+	mockLog.EXPECT().Debug().Return(noopLogger.Debug()).AnyTimes()
+	mockLog.EXPECT().Info().Return(noopLogger.Info()).AnyTimes()
+	mockLog.EXPECT().Warn().Return(noopLogger.Warn()).AnyTimes()
+	mockLog.EXPECT().Error().Return(noopLogger.Error()).AnyTimes()
+
+	m := Model{log: mockLog, loader: NewLoader()}
+	m.state.services = make(map[string]*ServiceState)
+	m.state.restarting = make(map[string]bool)
+	m.state.tiers = make([]Tier, 0)
+
+	event1 := bus.Message{
+		Type: bus.EventProfileResolved,
+		Data: bus.ProfileResolved{
+			Profile: "profile1",
+			Tiers: []bus.Tier{
+				{Name: "tier1", Services: []bus.Service{{ID: "test-id-db", Name: "db"}}},
+			},
+		},
+	}
+
+	result := m.handleProfileResolved(event1)
+	result.state.services["test-id-db"].Timeline.Append(SlotRunning)
+	result.state.services["test-id-db"].Timeline.Append(SlotRunning)
+	assert.Equal(t, 2, result.state.services["test-id-db"].Timeline.count)
+
+	event2 := bus.Message{
+		Type: bus.EventProfileResolved,
+		Data: bus.ProfileResolved{
+			Profile: "profile2",
+			Tiers: []bus.Tier{
+				{Name: "tier1", Services: []bus.Service{{ID: "test-id-db", Name: "db"}}},
+			},
+		},
+	}
+
+	result = result.handleProfileResolved(event2)
+	assert.Equal(t, 0, result.state.services["test-id-db"].Timeline.count, "timeline should be fresh after profile reload")
+}
+
+func Test_SampleTimelines(t *testing.T) {
+	started := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	m := Model{}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:        "id-api",
+			Name:      "api",
+			Status:    StatusRunning,
+			StartTime: started,
+			Timeline:  NewTimeline(components.DefaultTimelineSlots),
+		},
+		"id-db": {
+			ID:        "id-db",
+			Name:      "db",
+			Status:    StatusStarting,
+			StartTime: started,
+			Timeline:  NewTimeline(components.DefaultTimelineSlots),
+		},
+		"id-web": {
+			ID:        "id-web",
+			Name:      "web",
+			Status:    StatusFailed,
+			StartTime: started,
+			Timeline:  NewTimeline(components.DefaultTimelineSlots),
+		},
+		"id-queued": {
+			ID:       "id-queued",
+			Name:     "queued",
+			Status:   StatusStarting,
+			Timeline: NewTimeline(components.DefaultTimelineSlots),
+		},
+		"id-stopped": {
+			ID:       "id-stopped",
+			Name:     "stopped",
+			Status:   StatusStopped,
+			Timeline: timelineWithHistory(SlotRunning),
+		},
+		"id-preflight-fail": {
+			ID:       "id-preflight-fail",
+			Name:     "preflight-fail",
+			Status:   StatusFailed,
+			Timeline: NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+
+	m.sampleTimelines()
+
+	assert.Equal(t, 1, m.state.services["id-api"].Timeline.count)
+	assert.Equal(t, SlotRunning, m.state.services["id-api"].Timeline.Slots()[0])
+
+	assert.Equal(t, 1, m.state.services["id-db"].Timeline.count)
+	assert.Equal(t, SlotStarting, m.state.services["id-db"].Timeline.Slots()[0])
+
+	assert.Equal(t, 1, m.state.services["id-web"].Timeline.count)
+	assert.Equal(t, SlotFailed, m.state.services["id-web"].Timeline.Slots()[0])
+
+	assert.Equal(t, 0, m.state.services["id-queued"].Timeline.count)
+
+	assert.Equal(t, 2, m.state.services["id-stopped"].Timeline.count)
+	assert.Equal(t, SlotStopped, m.state.services["id-stopped"].Timeline.Slots()[1])
+
+	assert.Equal(t, 1, m.state.services["id-preflight-fail"].Timeline.count)
+	assert.Equal(t, SlotFailed, m.state.services["id-preflight-fail"].Timeline.Slots()[0])
+}
+
+func Test_SampleTimelines_MultipleSamples(t *testing.T) {
+	started := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	m := Model{}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:        "id-api",
+			Name:      "api",
+			Status:    StatusStarting,
+			StartTime: started,
+			Timeline:  NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+
+	m.sampleTimelines()
+	m.state.services["id-api"].Status = StatusRunning
+	m.sampleTimelines()
+	m.sampleTimelines()
+
+	slots := m.state.services["id-api"].Timeline.Slots()
+	assert.Equal(t, SlotStarting, slots[0])
+	assert.Equal(t, SlotRunning, slots[1])
+	assert.Equal(t, SlotRunning, slots[2])
+	assert.Equal(t, SlotEmpty, slots[3])
+}
+
+func timelineWithHistory(slots ...TimelineSlot) *Timeline {
+	tl := NewTimeline(components.DefaultTimelineSlots)
+	for _, s := range slots {
+		tl.Append(s)
+	}
+
+	return tl
+}
+
+func Test_RefreshFromStore_StaleSnapshotDoesNotRevertStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Second)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:           "id-api",
+			Status:       registry.StatusStarting,
+			PID:          1234,
+			CPU:          10.0,
+			Memory:       128 * 1024 * 1024,
+			StartTime:    t0,
+			LifecycleAt:  t0,
+			LifecycleSeq: 1,
+		},
+	})
+
+	m := &Model{store: mockStore, loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.restarting = map[string]bool{}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:           "id-api",
+			Name:         "api",
+			Status:       StatusFailed,
+			PID:          0,
+			StartTime:    time.Time{},
+			Error:        assert.AnError,
+			LifecycleAt:  t1,
+			LifecycleSeq: 2,
+			Timeline:     timelineWithHistory(SlotStarting, SlotFailed),
+		},
+	}
+
+	m.refreshFromStore()
+	m.sampleTimelines()
+
+	api := m.state.services["id-api"]
+	assert.Equal(t, StatusFailed, api.Status)
+	require.EqualError(t, api.Error, assert.AnError.Error())
+	assert.True(t, api.StartTime.IsZero())
+	assert.Equal(t, 0, api.PID)
+	assert.InDelta(t, 0.0, api.CPU, 0.01)
+	assert.InDelta(t, 0.0, api.MEM, 0.01)
+
+	slots := api.Timeline.Slots()
+	assert.Equal(t, SlotStarting, slots[0])
+	assert.Equal(t, SlotFailed, slots[1])
+	assert.Equal(t, SlotFailed, slots[2])
+}
+
+func Test_DelayedStartingDoesNotRevertReady(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Second)
+	t2 := t0.Add(2 * time.Second)
+
+	m := Model{loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:       "id-api",
+			Name:     "api",
+			Timeline: NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m = m.handleServiceReady(bus.Message{
+		Type:      bus.EventServiceReady,
+		Timestamp: t2,
+		Seq:       2,
+		Data: bus.ServiceReady{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "id-api", Name: "api"}, Tier: "platform"},
+			PID:          5678,
+			StartedAt:    t1,
+		},
+	})
+
+	m = m.handleServiceStarting(bus.Message{
+		Type:      bus.EventServiceStarting,
+		Timestamp: t1,
+		Seq:       1,
+		Data:      bus.ServiceStarting{ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "id-api", Name: "api"}}, PID: 5678},
+	})
+
+	api := m.state.services["id-api"]
+	assert.Equal(t, StatusRunning, api.Status)
+	assert.Equal(t, 5678, api.PID)
+	assert.Equal(t, t1, api.StartTime)
+	assert.Equal(t, t2, api.LifecycleAt)
+}
+
+func Test_TimelineSamplesReconciledState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Second)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:           "id-api",
+			Status:       registry.StatusRunning,
+			PID:          5678,
+			StartTime:    t0,
+			LifecycleAt:  t1,
+			LifecycleSeq: 2,
+		},
+	})
+
+	m := &Model{store: mockStore, loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.restarting = map[string]bool{}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:            "id-api",
+			Name:          "api",
+			Status:        StatusStarting,
+			PID:           5678,
+			StartTime:     t0,
+			LifecycleAt:   t0,
+			LifecycleSeq:  1,
+			BackfilledSeq: 2,
+			Timeline:      timelineWithHistory(SlotStarting),
+		},
+	}
+
+	m.refreshFromStore()
+	m.sampleTimelines()
+
+	api := m.state.services["id-api"]
+	assert.Equal(t, registry.StatusRunning, api.Status)
+
+	slots := api.Timeline.Slots()
+	assert.Equal(t, SlotStarting, slots[0])
+	assert.Equal(t, SlotRunning, slots[1])
+}
+
+func Test_HandleServiceReady_ClearsErrorAndRestarting(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Second)
+
+	m := Model{loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:          "id-api",
+			Name:        "api",
+			Status:      StatusRestarting,
+			Error:       assert.AnError,
+			LifecycleAt: t0,
+		},
+	}
+	m.state.restarting = map[string]bool{"id-api": true}
+
+	m = m.handleServiceReady(bus.Message{
+		Type:      bus.EventServiceReady,
+		Timestamp: t1,
+		Seq:       2,
+		Data: bus.ServiceReady{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "id-api", Name: "api"}, Tier: "platform"},
+			PID:          9876,
+			StartedAt:    t0,
+		},
+	})
+
+	api := m.state.services["id-api"]
+	assert.Equal(t, StatusRunning, api.Status)
+	assert.Equal(t, 9876, api.PID)
+	assert.Equal(t, t0, api.StartTime)
+	require.NoError(t, api.Error)
+	assert.False(t, m.state.restarting["id-api"])
+}
+
+func Test_SameSeqReadyHealingAllowsRunningTimelineSample(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:           "id-api",
+			Status:       registry.StatusRunning,
+			PID:          5678,
+			StartTime:    t0,
+			LifecycleAt:  t0,
+			LifecycleSeq: 10,
+		},
+	})
+
+	m := &Model{store: mockStore, loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.restarting = map[string]bool{}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:           "id-api",
+			Name:         "api",
+			Status:       StatusRunning,
+			LifecycleAt:  t0,
+			LifecycleSeq: 10,
+			Timeline:     NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+
+	m.refreshFromStore()
+	m.sampleTimelines()
+
+	api := m.state.services["id-api"]
+	assert.Equal(t, t0, api.StartTime)
+	assert.Equal(t, 1, api.Timeline.Count())
+	assert.Equal(t, SlotRunning, api.Timeline.Slots()[0])
+}
+
+func Test_HandleServiceReady_BackfillsStartupHistory(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	m := Model{loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:       "id-api",
+			Name:     "api",
+			Status:   StatusStarting,
+			Timeline: NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m = m.handleServiceReady(bus.Message{
+		Type:      bus.EventServiceReady,
+		Timestamp: t0.Add(3 * time.Second),
+		Seq:       2,
+		Data: bus.ServiceReady{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "id-api", Name: "api"}},
+			PID:          1234,
+			StartedAt:    t0,
+			Duration:     3 * time.Second,
+		},
+	})
+
+	tl := m.state.services["id-api"].Timeline
+	assert.Equal(t, 3, tl.Count())
+
+	slots := tl.Slots()
+	assert.Equal(t, SlotStarting, slots[0])
+	assert.Equal(t, SlotStarting, slots[1])
+	assert.Equal(t, SlotStarting, slots[2])
+}
+
+func Test_HandleServiceReady_NoBackfillWhenHistoryExists(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tl := NewTimeline(components.DefaultTimelineSlots)
+	tl.Append(SlotStarting)
+	tl.Append(SlotStarting)
+
+	m := Model{loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:               "id-api",
+			Name:             "api",
+			Status:           StatusStarting,
+			PID:              1234,
+			StartTime:        t0,
+			AttemptStartedAt: t0,
+			StartupSampled:   2,
+			BackfilledSeq:    2,
+			Timeline:         tl,
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m = m.handleServiceReady(bus.Message{
+		Type:      bus.EventServiceReady,
+		Timestamp: t0.Add(3 * time.Second),
+		Seq:       2,
+		Data: bus.ServiceReady{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "id-api", Name: "api"}},
+			PID:          1234,
+			StartedAt:    t0,
+			Duration:     3 * time.Second,
+		},
+	})
+
+	assert.Equal(t, 2, m.state.services["id-api"].Timeline.Count())
+}
+
+func Test_HandleServiceReady_ZerosMetricsOnNewProcess(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	m := Model{loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:     "id-api",
+			Name:   "api",
+			Status: StatusStarting,
+			CPU:    45.0,
+			MEM:    512.0,
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m = m.handleServiceReady(bus.Message{
+		Type:      bus.EventServiceReady,
+		Timestamp: t0,
+		Seq:       1,
+		Data: bus.ServiceReady{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "id-api", Name: "api"}},
+			PID:          5678,
+			StartedAt:    t0,
+		},
+	})
+
+	api := m.state.services["id-api"]
+	assert.InDelta(t, 0.0, api.CPU, 0.01)
+	assert.InDelta(t, 0.0, api.MEM, 0.01)
+}
+
+func Test_HandleServiceReady_PreservesMetricsOnSameProcess(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	m := Model{loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:               "id-api",
+			Name:             "api",
+			Status:           StatusStarting,
+			PID:              5678,
+			StartTime:        t0,
+			AttemptStartedAt: t0,
+			CPU:              25.5,
+			MEM:              256.0,
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m = m.handleServiceReady(bus.Message{
+		Type:      bus.EventServiceReady,
+		Timestamp: t0.Add(time.Second),
+		Seq:       2,
+		Data: bus.ServiceReady{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "id-api", Name: "api"}},
+			PID:          5678,
+			StartedAt:    t0,
+		},
+	})
+
+	api := m.state.services["id-api"]
+	assert.InDelta(t, 25.5, api.CPU, 0.01)
+	assert.InDelta(t, 256.0, api.MEM, 0.01)
+}
+
+func Test_RefreshBeforeReady_StillBackfillsStartupHistory(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(3 * time.Second)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:               "id-api",
+			Status:           registry.StatusRunning,
+			PID:              5678,
+			StartTime:        t0,
+			AttemptStartedAt: t0,
+			LifecycleAt:      t1,
+			LifecycleSeq:     5,
+		},
+	})
+
+	m := &Model{
+		store:  mockStore,
+		loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)},
+	}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:       "id-api",
+			Name:     "api",
+			Status:   StatusStarting,
+			Timeline: NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m.refreshFromStore()
+	m.sampleTimelines()
+
+	tl := m.state.services["id-api"].Timeline
+	slots := tl.Slots()
+	assert.Equal(t, 4, tl.Count())
+	assert.Equal(t, SlotStarting, slots[0])
+	assert.Equal(t, SlotStarting, slots[1])
+	assert.Equal(t, SlotStarting, slots[2])
+	assert.Equal(t, SlotRunning, slots[3])
+
+	m2 := m.handleServiceReady(bus.Message{
+		Type:      bus.EventServiceReady,
+		Timestamp: t1,
+		Seq:       5,
+		Data: bus.ServiceReady{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "id-api", Name: "api"}},
+			PID:          5678,
+			StartedAt:    t0,
+			Duration:     3 * time.Second,
+		},
+	})
+
+	assert.Equal(t, 4, m2.state.services["id-api"].Timeline.Count())
+}
+
+func Test_SameSeqReadyAfterStoreHeal_RunsSideEffects(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:           "id-api",
+			Status:       registry.StatusRunning,
+			PID:          5678,
+			StartTime:    t0,
+			LifecycleAt:  t0,
+			LifecycleSeq: 5,
+		},
+	})
+
+	loader := &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}
+	loader.Start("id-api", "starting api...")
+
+	m := &Model{store: mockStore, loader: loader}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:       "id-api",
+			Name:     "api",
+			Status:   StatusStarting,
+			Timeline: NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+	m.state.restarting = map[string]bool{"id-api": true}
+
+	m.refreshFromStore()
+
+	assert.Equal(t, StatusRunning, m.state.services["id-api"].Status)
+	assert.Equal(t, uint64(5), m.state.services["id-api"].LifecycleSeq)
+	assert.False(t, m.loader.Active)
+	assert.False(t, m.state.restarting["id-api"])
+
+	result := m.handleServiceReady(bus.Message{
+		Type:      bus.EventServiceReady,
+		Timestamp: t0,
+		Seq:       5,
+		Data: bus.ServiceReady{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "id-api", Name: "api"}},
+			PID:          5678,
+			StartedAt:    t0.Add(-3 * time.Second),
+			Duration:     3 * time.Second,
+		},
+	})
+
+	assert.False(t, result.loader.Active)
+	assert.False(t, result.loader.Has("id-api"))
+	assert.False(t, result.state.restarting["id-api"])
+	assert.Equal(t, 3, result.state.services["id-api"].Timeline.Count())
+}
+
+func Test_LateStartingDoesNotResetStartupSampled(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	m := Model{loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:               "id-api",
+			Name:             "api",
+			Status:           StatusStarting,
+			PID:              5678,
+			StartTime:        t0,
+			AttemptStartedAt: t0,
+			StartupSampled:   3,
+			BackfilledSeq:    0,
+			LifecycleSeq:     5,
+			Timeline:         NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m = m.handleServiceStarting(bus.Message{
+		Type:      bus.EventServiceStarting,
+		Timestamp: t0,
+		Seq:       5,
+		Data: bus.ServiceStarting{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "id-api", Name: "api"}},
+			PID:          5678,
+			StartedAt:    t0,
+		},
+	})
+
+	assert.Equal(t, 3, m.state.services["id-api"].StartupSampled)
+}
+
+func Test_RestartReadyBeforeStarting_BackfillsAmber(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(3 * time.Second)
+
+	tl := NewTimeline(components.DefaultTimelineSlots)
+	tl.Append(SlotRunning)
+	tl.Append(SlotRunning)
+
+	m := Model{loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:             "id-api",
+			Name:           "api",
+			Status:         StatusRunning,
+			PID:            1111,
+			StartTime:      t0.Add(-10 * time.Second),
+			StartupSampled: 2,
+			BackfilledSeq:  1,
+			LifecycleSeq:   1,
+			Timeline:       tl,
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m = m.handleServiceReady(bus.Message{
+		Type:      bus.EventServiceReady,
+		Timestamp: t1,
+		Seq:       3,
+		Data: bus.ServiceReady{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "id-api", Name: "api"}},
+			PID:          2222,
+			StartedAt:    t0,
+			Duration:     3 * time.Second,
+		},
+	})
+
+	svc := m.state.services["id-api"]
+	assert.Equal(t, 2222, svc.PID)
+	assert.Equal(t, 5, svc.Timeline.Count())
+
+	slots := svc.Timeline.Slots()
+	assert.Equal(t, SlotRunning, slots[0])
+	assert.Equal(t, SlotRunning, slots[1])
+	assert.Equal(t, SlotStarting, slots[2])
+	assert.Equal(t, SlotStarting, slots[3])
+	assert.Equal(t, SlotStarting, slots[4])
+}
+
+func Test_SameSeqReadyAfterRefresh_NewProcessStillBackfills(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(2 * time.Second)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:               "id-api",
+			Status:           registry.StatusRunning,
+			PID:              2222,
+			StartTime:        t0,
+			AttemptStartedAt: t0,
+			LifecycleAt:      t1,
+			LifecycleSeq:     5,
+		},
+	})
+
+	oldStart := t0.Add(-10 * time.Second)
+
+	m := &Model{
+		store:  mockStore,
+		loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)},
+	}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:               "id-api",
+			Name:             "api",
+			Status:           StatusRunning,
+			PID:              1111,
+			StartTime:        oldStart,
+			AttemptStartedAt: oldStart,
+			StartupSampled:   5,
+			BackfilledSeq:    3,
+			LifecycleSeq:     3,
+			Timeline:         NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m.refreshFromStore()
+
+	svc := m.state.services["id-api"]
+	assert.Equal(t, 2222, svc.PID)
+	assert.Equal(t, 2, svc.Timeline.Count())
+
+	slots := svc.Timeline.Slots()
+	assert.Equal(t, SlotStarting, slots[0])
+	assert.Equal(t, SlotStarting, slots[1])
+
+	m2 := m.handleServiceReady(bus.Message{
+		Type:      bus.EventServiceReady,
+		Timestamp: t1,
+		Seq:       5,
+		Data: bus.ServiceReady{
+			ServiceEvent: bus.ServiceEvent{Service: bus.Service{ID: "id-api", Name: "api"}},
+			PID:          2222,
+			StartedAt:    t0,
+			Duration:     2 * time.Second,
+		},
+	})
+
+	assert.Equal(t, 2, m2.state.services["id-api"].Timeline.Count())
+}
+
+func Test_ReconcileLifecycle_ClearsRestartingAndStopsLoader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:           "id-api",
+			Status:       registry.StatusRunning,
+			PID:          5678,
+			StartTime:    t0,
+			LifecycleAt:  t0.Add(3 * time.Second),
+			LifecycleSeq: 5,
+		},
+	})
+
+	loader := &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}
+	loader.Start("id-api", "restarting api...")
+
+	m := &Model{
+		store:  mockStore,
+		loader: loader,
+	}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:           "id-api",
+			Name:         "api",
+			Status:       StatusRestarting,
+			PID:          5678,
+			StartTime:    t0,
+			LifecycleSeq: 3,
+		},
+	}
+	m.state.restarting = map[string]bool{"id-api": true}
+
+	m.refreshFromStore()
+
+	assert.Equal(t, StatusRunning, m.state.services["id-api"].Status)
+	assert.False(t, m.loader.Active)
+	assert.False(t, m.loader.Has("id-api"))
+	assert.False(t, m.state.restarting["id-api"])
+}
+
+func Test_ReconcileLifecycle_StartingToFailed_BackfillsAmber(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(3 * time.Second)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:           "id-api",
+			Status:       registry.StatusFailed,
+			Error:        "crash",
+			LifecycleAt:  t1,
+			LifecycleSeq: 5,
+		},
+	})
+
+	m := &Model{
+		store:  mockStore,
+		loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)},
+	}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:               "id-api",
+			Name:             "api",
+			Status:           StatusStarting,
+			StartupActive:    true,
+			PID:              1234,
+			StartTime:        t0,
+			AttemptStartedAt: t0,
+			LifecycleSeq:     3,
+			Timeline:         NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m.refreshFromStore()
+	m.sampleTimelines()
+
+	svc := m.state.services["id-api"]
+	assert.Equal(t, StatusFailed, svc.Status)
+
+	slots := svc.Timeline.Slots()
+	assert.Equal(t, SlotStarting, slots[0])
+	assert.Equal(t, SlotStarting, slots[1])
+	assert.Equal(t, SlotStarting, slots[2])
+	assert.Equal(t, SlotFailed, slots[3])
+}
+
+func Test_ReconcileLifecycle_StartingToStopped_BackfillsAmber(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(2 * time.Second)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:           "id-api",
+			Status:       registry.StatusStopped,
+			LifecycleAt:  t1,
+			LifecycleSeq: 5,
+		},
+	})
+
+	m := &Model{
+		store:  mockStore,
+		loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)},
+	}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:               "id-api",
+			Name:             "api",
+			Status:           StatusStarting,
+			StartupActive:    true,
+			PID:              1234,
+			StartTime:        t0,
+			AttemptStartedAt: t0,
+			LifecycleSeq:     3,
+			Timeline:         NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m.refreshFromStore()
+	m.sampleTimelines()
+
+	svc := m.state.services["id-api"]
+	assert.Equal(t, StatusStopped, svc.Status)
+
+	slots := svc.Timeline.Slots()
+	assert.Equal(t, SlotStarting, slots[0])
+	assert.Equal(t, SlotStarting, slots[1])
+	assert.Equal(t, SlotStopped, slots[2])
+}
+
+func Test_ReconcileLifecycle_RestartingStopped_KeepsLoader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:           "id-api",
+			Status:       registry.StatusStopped,
+			LifecycleAt:  t0,
+			LifecycleSeq: 5,
+		},
+	})
+
+	loader := &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)}
+	loader.Start("id-api", "restarting api...")
+
+	m := &Model{
+		store:  mockStore,
+		loader: loader,
+	}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:           "id-api",
+			Name:         "api",
+			Status:       StatusRestarting,
+			LifecycleSeq: 3,
+		},
+	}
+	m.state.restarting = map[string]bool{"id-api": true}
+
+	m.refreshFromStore()
+
+	assert.Equal(t, StatusStopped, m.state.services["id-api"].Status)
+	assert.True(t, m.loader.Active)
+	assert.True(t, m.state.restarting["id-api"])
+}
+
+func Test_ReconcileLifecycle_RestartingWithOldStartTime_NoBackfill(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:           "id-api",
+			Status:       registry.StatusStopped,
+			LifecycleAt:  t0.Add(30 * time.Second),
+			LifecycleSeq: 5,
+		},
+	})
+
+	m := &Model{
+		store:  mockStore,
+		loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)},
+	}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:           "id-api",
+			Name:         "api",
+			Status:       StatusStopping,
+			PID:          1234,
+			StartTime:    t0,
+			LifecycleSeq: 3,
+			Timeline:     NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m.refreshFromStore()
+
+	assert.Equal(t, 0, m.state.services["id-api"].Timeline.Count())
+}
+
+func Test_ReconcileLifecycle_RealStartingToFailed_StillBackfills(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:           "id-api",
+			Status:       registry.StatusFailed,
+			Error:        "crash",
+			LifecycleAt:  t0.Add(3 * time.Second),
+			LifecycleSeq: 5,
+		},
+	})
+
+	m := &Model{
+		store:  mockStore,
+		loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)},
+	}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:               "id-api",
+			Name:             "api",
+			Status:           StatusStarting,
+			StartupActive:    true,
+			PID:              1234,
+			StartTime:        t0,
+			AttemptStartedAt: t0,
+			LifecycleSeq:     3,
+			Timeline:         NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m.refreshFromStore()
+
+	assert.Equal(t, 3, m.state.services["id-api"].Timeline.Count())
+
+	slots := m.state.services["id-api"].Timeline.Slots()
+	assert.Equal(t, SlotStarting, slots[0])
+	assert.Equal(t, SlotStarting, slots[1])
+	assert.Equal(t, SlotStarting, slots[2])
+}
+
+func Test_ReconcileLifecycle_MissedStartup_FailedSnapshotBackfills(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:               "id-api",
+			Status:           registry.StatusFailed,
+			Error:            "crash",
+			PID:              0,
+			AttemptStartedAt: t0,
+			LifecycleAt:      t0.Add(3 * time.Second),
+			LifecycleSeq:     5,
+		},
+	})
+
+	m := &Model{
+		store:  mockStore,
+		loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)},
+	}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:           "id-api",
+			Name:         "api",
+			Status:       StatusStopped,
+			LifecycleSeq: 1,
+			Timeline:     NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m.refreshFromStore()
+	m.sampleTimelines()
+
+	svc := m.state.services["id-api"]
+	assert.Equal(t, StatusFailed, svc.Status)
+	assert.Equal(t, 4, svc.Timeline.Count())
+
+	slots := svc.Timeline.Slots()
+	assert.Equal(t, SlotStarting, slots[0])
+	assert.Equal(t, SlotStarting, slots[1])
+	assert.Equal(t, SlotStarting, slots[2])
+	assert.Equal(t, SlotFailed, slots[3])
+}
+
+func Test_ReconcileLifecycle_MissedStartup_RestartFailedBackfills(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	oldStart := t0.Add(-60 * time.Second)
+
+	mockStore := registry.NewMockStore(ctrl)
+	mockStore.EXPECT().Services().Return([]registry.ServiceSnapshot{
+		{
+			ID:               "id-api",
+			Status:           registry.StatusFailed,
+			Error:            "crash",
+			AttemptStartedAt: t0,
+			LifecycleAt:      t0.Add(2 * time.Second),
+			LifecycleSeq:     10,
+		},
+	})
+
+	m := &Model{
+		store:  mockStore,
+		loader: &Loader{Model: spinner.New(), queue: make([]LoaderItem, 0)},
+	}
+	m.state.services = map[string]*ServiceState{
+		"id-api": {
+			ID:               "id-api",
+			Name:             "api",
+			Status:           StatusRunning,
+			PID:              1111,
+			StartTime:        oldStart,
+			AttemptStartedAt: oldStart,
+			LifecycleSeq:     5,
+			Timeline:         NewTimeline(components.DefaultTimelineSlots),
+		},
+	}
+	m.state.restarting = map[string]bool{}
+
+	m.refreshFromStore()
+
+	svc := m.state.services["id-api"]
+	assert.Equal(t, StatusFailed, svc.Status)
+	assert.Equal(t, 2, svc.Timeline.Count())
+
+	slots := svc.Timeline.Slots()
+	assert.Equal(t, SlotStarting, slots[0])
+	assert.Equal(t, SlotStarting, slots[1])
 }
 
 func toKeyMsg(s string) tea.KeyPressMsg {

--- a/internal/app/ui/services/view.go
+++ b/internal/app/ui/services/view.go
@@ -355,26 +355,43 @@ func (m Model) renderServiceRow(service *ServiceState, isSelected bool) string {
 		style = m.theme.SelectedRowStyle
 	}
 
-	row := m.buildServiceRow(nameCol, timelineCol, statusCol, details, service.Error != nil, isSelected, rowWidth)
+	row := m.buildServiceRow(rowParts{
+		name:       nameCol,
+		timeline:   timelineCol,
+		status:     statusCol,
+		details:    details,
+		hasError:   service.Error != nil,
+		isSelected: isSelected,
+	}, rowWidth)
 
 	return style.Width(rowWidth).Render(row)
 }
 
-// buildServiceRow positions details: errors left-aligned after status, metrics right-aligned to edge
-func (m Model) buildServiceRow(nameCol, timelineCol, statusCol, details string, hasError, isSelected bool, rowWidth int) string {
-	gap := strings.Repeat(" ", m.ui.layout.TimelineGapWidth)
-	tail := gap + statusCol + details
+// rowParts groups the column segments for a service row
+type rowParts struct {
+	name       string
+	timeline   string
+	status     string
+	details    string
+	hasError   bool
+	isSelected bool
+}
 
-	if hasError {
-		remaining := max(rowWidth-lipgloss.Width(nameCol)-lipgloss.Width(timelineCol), 0)
+// buildServiceRow positions details: errors left-aligned after status, metrics right-aligned to edge
+func (m Model) buildServiceRow(parts rowParts, rowWidth int) string {
+	gap := strings.Repeat(" ", m.ui.layout.TimelineGapWidth)
+	tail := gap + parts.status + parts.details
+
+	if parts.hasError {
+		remaining := max(rowWidth-lipgloss.Width(parts.name)-lipgloss.Width(parts.timeline), 0)
 		tail = components.PadRight(tail, remaining)
 	}
 
-	if isSelected && m.ui.layout.TimelineWidth > 0 {
+	if parts.isSelected && m.ui.layout.TimelineWidth > 0 {
 		tail = lipgloss.NewStyle().Background(m.theme.BgSelection).Render(tail)
 	}
 
-	return nameCol + timelineCol + tail
+	return parts.name + parts.timeline + tail
 }
 
 // getServiceDetails returns either error message or metrics columns

--- a/internal/app/ui/services/view.go
+++ b/internal/app/ui/services/view.go
@@ -204,11 +204,12 @@ func (m Model) getRowWidth() int {
 // renderColumnHeaders renders the column headers row
 func (m Model) renderColumnHeaders() string {
 	nameCol := strings.Repeat(" ", m.ui.layout.ServiceNameWidth)
+	timelineCol := strings.Repeat(" ", m.ui.layout.TimelineWidth+m.ui.layout.TimelineGapWidth)
 	statusCol := fmt.Sprintf("%-*s", m.ui.layout.StatusWidth, "status")
 	w := m.ui.layout.MetricWidth
 	metricsCol := fmt.Sprintf("%*s%*s%*s%*s", w, "cpu", w, "mem", w, "pid", w, "uptime")
 
-	header := nameCol + statusCol + metricsCol
+	header := nameCol + timelineCol + statusCol + metricsCol
 
 	return m.theme.ServiceHeaderStyle.Width(m.getRowWidth()).Render(header)
 }
@@ -272,6 +273,69 @@ func (m Model) getWatchIndicator(isSelected bool) string {
 	return m.theme.IndicatorDotStyle.Render(components.IndicatorDot)
 }
 
+// renderTimeline renders the timeline strip for a service
+func (m Model) renderTimeline(service *ServiceState, isSelected bool) string {
+	tw := m.ui.layout.TimelineWidth
+	if tw == 0 {
+		return ""
+	}
+
+	if service.Timeline == nil {
+		return strings.Repeat(" ", tw)
+	}
+
+	slots := service.Timeline.Slots()
+	count := service.Timeline.Count()
+
+	visibleObserved := min(tw, count)
+	emptyPad := tw - visibleObserved
+	observedStart := count - visibleObserved
+
+	var b strings.Builder
+
+	for i := observedStart; i < observedStart+visibleObserved; i++ {
+		b.WriteString(m.timelineSlotStyle(slots[i], isSelected).Render(components.TimelineBlock))
+	}
+
+	emptyStyle := m.timelineSlotStyle(SlotEmpty, isSelected)
+	for range emptyPad {
+		b.WriteString(emptyStyle.Render(components.TimelineBlock))
+	}
+
+	return b.String()
+}
+
+// timelineSlotStyle returns the style for a timeline slot, composing with BgSelection when selected
+func (m Model) timelineSlotStyle(slot TimelineSlot, isSelected bool) lipgloss.Style {
+	if isSelected {
+		switch slot {
+		case SlotRunning:
+			return m.theme.TimelineSelectedRunningStyle
+		case SlotStarting:
+			return m.theme.TimelineSelectedStartingStyle
+		case SlotFailed:
+			return m.theme.TimelineSelectedFailedStyle
+		case SlotStopped:
+			return m.theme.TimelineSelectedStoppedStyle
+		default:
+			return m.theme.TimelineSelectedEmptyStyle
+		}
+	}
+
+	switch slot {
+	case SlotRunning:
+		return m.theme.TimelineRunningStyle
+	case SlotStarting:
+		return m.theme.TimelineStartingStyle
+	case SlotFailed:
+		return m.theme.TimelineFailedStyle
+	case SlotStopped:
+		return m.theme.TimelineStoppedStyle
+	default:
+		return m.theme.TimelineEmptyStyle
+	}
+}
+
 // renderServiceRow renders a single service row with all columns
 func (m Model) renderServiceRow(service *ServiceState, isSelected bool) string {
 	rowWidth := m.getRowWidth()
@@ -281,6 +345,8 @@ func (m Model) renderServiceRow(service *ServiceState, isSelected bool) string {
 	name := components.TruncateAndPad(service.Name, nameTextWidth)
 	nameCol := fmt.Sprintf("%s %s", indicator, name)
 
+	timelineCol := m.renderTimeline(service, isSelected)
+
 	statusCol := m.getStyledAndPaddedStatus(service, isSelected)
 	details := m.getServiceDetails(service, isSelected)
 
@@ -289,19 +355,26 @@ func (m Model) renderServiceRow(service *ServiceState, isSelected bool) string {
 		style = m.theme.SelectedRowStyle
 	}
 
-	row := m.buildServiceRow(nameCol, statusCol, details, service.Error != nil, rowWidth)
+	row := m.buildServiceRow(nameCol, timelineCol, statusCol, details, service.Error != nil, isSelected, rowWidth)
 
 	return style.Width(rowWidth).Render(row)
 }
 
 // buildServiceRow positions details: errors left-aligned after status, metrics right-aligned to edge
-func (m Model) buildServiceRow(nameCol, statusCol, details string, hasError bool, rowWidth int) string {
-	row := nameCol + statusCol + details
+func (m Model) buildServiceRow(nameCol, timelineCol, statusCol, details string, hasError, isSelected bool, rowWidth int) string {
+	gap := strings.Repeat(" ", m.ui.layout.TimelineGapWidth)
+	tail := gap + statusCol + details
+
 	if hasError {
-		return components.PadRight(row, rowWidth)
+		remaining := max(rowWidth-lipgloss.Width(nameCol)-lipgloss.Width(timelineCol), 0)
+		tail = components.PadRight(tail, remaining)
 	}
 
-	return row
+	if isSelected && m.ui.layout.TimelineWidth > 0 {
+		tail = lipgloss.NewStyle().Background(m.theme.BgSelection).Render(tail)
+	}
+
+	return nameCol + timelineCol + tail
 }
 
 // getServiceDetails returns either error message or metrics columns

--- a/internal/app/ui/services/view_test.go
+++ b/internal/app/ui/services/view_test.go
@@ -436,10 +436,15 @@ func Test_RenderServiceRow_SelectedBackgroundCoversFullWidth(t *testing.T) {
 
 	row := m.renderServiceRow(service, true)
 
-	bgCode := "\x1b[48;5;235m"
-	parts := strings.Split(row, "running")
-	assert.Greater(t, len(parts), 1, "row must contain 'running' status")
-	assert.Contains(t, parts[1], bgCode, "selection background must cover metrics after timeline")
+	statusIndex := strings.Index(row, "running")
+	assert.NotEqual(t, -1, statusIndex, "row must contain 'running' status")
+
+	metricsIndex := strings.Index(row, "12345")
+	assert.NotEqual(t, -1, metricsIndex, "row must contain PID metrics")
+	assert.Greater(t, metricsIndex, statusIndex, "PID metrics must appear after status")
+
+	segment := row[statusIndex:metricsIndex]
+	assert.NotContains(t, segment, "\x1b[m", "selection background must not reset between status and metrics")
 }
 
 func Test_GetServiceDetails_WithError(t *testing.T) {

--- a/internal/app/ui/services/view_test.go
+++ b/internal/app/ui/services/view_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"strings"
 	"testing"
 
 	"charm.land/bubbles/v2/help"
@@ -252,7 +253,7 @@ func Test_RenderServiceRow_Truncation(t *testing.T) {
 			m.ui.width = tt.viewportWidth + 8
 			m.ui.layout = layoutForWidth(tt.viewportWidth)
 			m.ui.servicesViewport.SetWidth(tt.viewportWidth)
-			service := &ServiceState{Name: tt.serviceName, Status: StatusRunning}
+			service := &ServiceState{Name: tt.serviceName, Status: StatusRunning, Timeline: NewTimeline(components.DefaultTimelineSlots)}
 
 			result := m.renderServiceRow(service, false)
 
@@ -304,11 +305,12 @@ func Test_RenderNoWrapAtBreakpoints(t *testing.T) {
 			m.theme = components.DefaultTheme()
 
 			service := &ServiceState{
-				Name:   tt.serviceName,
-				Status: StatusRunning,
-				PID:    12345,
-				CPU:    99.9,
-				MEM:    512,
+				Name:     tt.serviceName,
+				Status:   StatusRunning,
+				PID:      12345,
+				CPU:      99.9,
+				MEM:      512,
+				Timeline: NewTimeline(components.DefaultTimelineSlots),
 			}
 
 			header := m.renderColumnHeaders()
@@ -318,6 +320,62 @@ func Test_RenderNoWrapAtBreakpoints(t *testing.T) {
 			assert.NotContains(t, row, "\n", "service row wraps")
 			assert.Equal(t, rowWidth, lipgloss.Width(header), "header width must equal rowWidth")
 			assert.Equal(t, rowWidth, lipgloss.Width(row), "service row width must equal rowWidth")
+		})
+	}
+}
+
+func Test_RenderServiceRow_SharedPrefixNamesDistinguishable(t *testing.T) {
+	tests := []struct {
+		name       string
+		panelWidth int
+	}{
+		{
+			name:       "72-col terminal",
+			panelWidth: 72,
+		},
+		{
+			name:       "84-col terminal",
+			panelWidth: 84,
+		},
+		{
+			name:       "90-col terminal",
+			panelWidth: 90,
+		},
+		{
+			name:       "104-col terminal",
+			panelWidth: 104,
+		},
+		{
+			name:       "120-col terminal",
+			panelWidth: 120,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rowWidth := tt.panelWidth - components.PanelInnerPadding
+
+			m := Model{}
+			m.ui.width = tt.panelWidth
+			m.ui.layout = layoutForWidth(rowWidth)
+			m.ui.servicesViewport.SetWidth(rowWidth)
+			m.theme = components.DefaultTheme()
+
+			svcA := &ServiceState{
+				Name:     "action-confirmation-management-service",
+				Status:   StatusRunning,
+				Timeline: NewTimeline(components.DefaultTimelineSlots),
+			}
+			svcB := &ServiceState{
+				Name:     "action-confirmation-metrics-service",
+				Status:   StatusRunning,
+				Timeline: NewTimeline(components.DefaultTimelineSlots),
+			}
+
+			rowA := m.renderServiceRow(svcA, false)
+			rowB := m.renderServiceRow(svcB, false)
+
+			assert.NotEqual(t, rowA, rowB, "shared-prefix names must produce different rows at %d columns", tt.panelWidth)
 		})
 	}
 }
@@ -353,6 +411,35 @@ func Test_RenderServiceRow_SelectedIndicator(t *testing.T) {
 
 	assert.Contains(t, notSelected, "  ")
 	assert.Contains(t, selected, components.IndicatorSelected+" ")
+}
+
+func Test_RenderServiceRow_SelectedBackgroundCoversFullWidth(t *testing.T) {
+	theme := components.DefaultTheme()
+	m := Model{theme: theme}
+	m.ui.width = 120
+	m.ui.layout = layoutForWidth(112)
+	m.ui.servicesViewport.SetWidth(112)
+
+	tl := NewTimeline(components.DefaultTimelineSlots)
+	for range 10 {
+		tl.Append(SlotRunning)
+	}
+
+	service := &ServiceState{
+		Name:     "api",
+		Status:   StatusRunning,
+		PID:      12345,
+		CPU:      1.5,
+		MEM:      64,
+		Timeline: tl,
+	}
+
+	row := m.renderServiceRow(service, true)
+
+	bgCode := "\x1b[48;5;235m"
+	parts := strings.Split(row, "running")
+	assert.Greater(t, len(parts), 1, "row must contain 'running' status")
+	assert.Contains(t, parts[1], bgCode, "selection background must cover metrics after timeline")
 }
 
 func Test_GetServiceDetails_WithError(t *testing.T) {
@@ -1048,6 +1135,172 @@ func Test_UpdateServicesContent_UsesFilteredTiers(t *testing.T) {
 	content := m.ui.servicesViewport.View()
 	assert.Contains(t, content, "api")
 	assert.NotContains(t, content, "db")
+}
+
+func Test_RenderTimeline_AllSlotTypes(t *testing.T) {
+	theme := components.DefaultTheme()
+	m := Model{theme: theme}
+	m.ui.layout = components.TableLayout{TimelineWidth: 5}
+
+	tl := NewTimeline(5)
+	tl.Append(SlotRunning)
+	tl.Append(SlotStarting)
+	tl.Append(SlotFailed)
+	tl.Append(SlotStopped)
+	tl.Append(SlotEmpty)
+
+	service := &ServiceState{Timeline: tl}
+
+	result := m.renderTimeline(service, false)
+
+	assert.Contains(t, result, theme.TimelineRunningStyle.Render(components.TimelineBlock))
+	assert.Contains(t, result, theme.TimelineStartingStyle.Render(components.TimelineBlock))
+	assert.Contains(t, result, theme.TimelineFailedStyle.Render(components.TimelineBlock))
+	assert.Contains(t, result, theme.TimelineStoppedStyle.Render(components.TimelineBlock))
+	assert.Contains(t, result, theme.TimelineEmptyStyle.Render(components.TimelineBlock))
+}
+
+func Test_RenderTimeline_SelectedUsesSelectedStyles(t *testing.T) {
+	theme := components.DefaultTheme()
+	m := Model{theme: theme}
+	m.ui.layout = components.TableLayout{TimelineWidth: 3}
+
+	tl := NewTimeline(3)
+	tl.Append(SlotRunning)
+	tl.Append(SlotFailed)
+	tl.Append(SlotStopped)
+
+	service := &ServiceState{Timeline: tl}
+
+	result := m.renderTimeline(service, true)
+
+	expected := theme.TimelineSelectedRunningStyle.Render(components.TimelineBlock) +
+		theme.TimelineSelectedFailedStyle.Render(components.TimelineBlock) +
+		theme.TimelineSelectedStoppedStyle.Render(components.TimelineBlock)
+	assert.Equal(t, expected, result)
+}
+
+func Test_RenderTimeline_ZeroWidthReturnsEmpty(t *testing.T) {
+	m := Model{}
+	m.ui.layout = components.TableLayout{TimelineWidth: 0}
+
+	service := &ServiceState{Timeline: NewTimeline(20)}
+
+	result := m.renderTimeline(service, false)
+	assert.Empty(t, result)
+}
+
+func Test_RenderTimeline_NilTimelineReturnsPadding(t *testing.T) {
+	m := Model{}
+	m.ui.layout = components.TableLayout{TimelineWidth: 10}
+
+	service := &ServiceState{Timeline: nil}
+
+	result := m.renderTimeline(service, false)
+	assert.Equal(t, strings.Repeat(" ", 10), result)
+}
+
+func Test_RenderTimeline_ReducedWidthShowsRecentSlots(t *testing.T) {
+	theme := components.DefaultTheme()
+	m := Model{theme: theme}
+	m.ui.layout = components.TableLayout{TimelineWidth: 5}
+
+	tl := NewTimeline(10)
+	for range 10 {
+		tl.Append(SlotRunning)
+	}
+
+	tl.Append(SlotFailed)
+
+	service := &ServiceState{Timeline: tl}
+
+	result := m.renderTimeline(service, false)
+
+	assert.Equal(t, 5, lipgloss.Width(result))
+	assert.Contains(t, result, theme.TimelineFailedStyle.Render(components.TimelineBlock))
+}
+
+func Test_RenderTimeline_ReducedWidthPartiallyFilled(t *testing.T) {
+	theme := components.DefaultTheme()
+	m := Model{theme: theme}
+	m.ui.layout = components.TableLayout{TimelineWidth: 5}
+
+	tl := NewTimeline(20)
+	tl.Append(SlotRunning)
+	tl.Append(SlotFailed)
+
+	service := &ServiceState{Timeline: tl}
+
+	result := m.renderTimeline(service, false)
+
+	assert.Equal(t, 5, lipgloss.Width(result))
+	assert.Contains(t, result, theme.TimelineRunningStyle.Render(components.TimelineBlock))
+	assert.Contains(t, result, theme.TimelineFailedStyle.Render(components.TimelineBlock))
+}
+
+func Test_RenderTimeline_SelectedUsesSelectionAwareStyles(t *testing.T) {
+	theme := components.DefaultTheme()
+	m := Model{theme: theme}
+	m.ui.layout = components.TableLayout{TimelineWidth: 5}
+
+	tl := NewTimeline(5)
+	tl.Append(SlotRunning)
+	tl.Append(SlotFailed)
+
+	service := &ServiceState{Timeline: tl}
+
+	result := m.renderTimeline(service, true)
+
+	runningBlock := theme.TimelineSelectedRunningStyle.Render(components.TimelineBlock)
+	failedBlock := theme.TimelineSelectedFailedStyle.Render(components.TimelineBlock)
+	emptyBlock := theme.TimelineSelectedEmptyStyle.Render(components.TimelineBlock)
+
+	expected := runningBlock + failedBlock + strings.Repeat(emptyBlock, 3)
+	assert.Equal(t, expected, result)
+}
+
+func Test_RenderServiceRow_WithTimeline(t *testing.T) {
+	theme := components.DefaultTheme()
+	m := Model{theme: theme}
+	m.ui.width = 120
+	m.ui.layout = layoutForWidth(112)
+	m.ui.servicesViewport.SetWidth(112)
+
+	tl := NewTimeline(components.DefaultTimelineSlots)
+	tl.Append(SlotRunning)
+
+	service := &ServiceState{Name: "api", Status: StatusRunning, Timeline: tl}
+
+	result := m.renderServiceRow(service, false)
+
+	assert.Contains(t, result, "api")
+	assert.Contains(t, result, "running")
+	assert.Contains(t, result, components.TimelineBlock)
+}
+
+func Test_RenderServiceRow_ErrorRowStillShowsTimeline(t *testing.T) {
+	theme := components.DefaultTheme()
+	m := Model{theme: theme}
+	m.ui.width = 120
+	m.ui.layout = layoutForWidth(112)
+	m.ui.servicesViewport.SetWidth(112)
+
+	tl := NewTimeline(components.DefaultTimelineSlots)
+	tl.Append(SlotFailed)
+
+	service := &ServiceState{
+		Name:     "api",
+		Status:   StatusFailed,
+		Error:    errors.ErrPortAlreadyInUse,
+		Timeline: tl,
+	}
+
+	result := m.renderServiceRow(service, false)
+
+	assert.Contains(t, result, "api")
+	assert.Contains(t, result, "failed")
+	assert.Contains(t, result, components.TimelineBlock)
+	assert.Contains(t, result, "port already in use")
 }
 
 func Test_UpdateServicesContent_EmptyFilterClearsViewport(t *testing.T) {


### PR DESCRIPTION
Display a compact uptime-style history per service row
Green for running, amber for starting/restarting/stopping, red for failed, gray for stopped