### PR TITLE
fix(log): Fix lifecycle logs

### DIFF
--- a/internal/app/api/server.go
+++ b/internal/app/api/server.go
@@ -96,7 +96,7 @@ func (s *Server) Shutdown(ctx context.Context) {
 		return
 	}
 
-	s.log.Info().Msg("API server shutting down")
+	s.log.Debug().Msg("API server shutting down")
 
 	//nolint:errcheck // best-effort graceful shutdown
 	s.httpServer.Shutdown(ctx)
@@ -107,7 +107,7 @@ func (s *Server) Shutdown(ctx context.Context) {
 		Critical: true,
 	})
 
-	s.log.Info().Msg("API server stopped")
+	s.log.Debug().Msg("API server stopped")
 }
 
 // listen attempts to bind the configured address with port retry

--- a/internal/app/api/server_test.go
+++ b/internal/app/api/server_test.go
@@ -44,6 +44,7 @@ func Test_Server_StartAndShutdown(t *testing.T) {
 
 	mockLog.EXPECT().WithComponent("API").Return(mockLog)
 	mockLog.EXPECT().Info().Return(logger.NewLoggerWithOutput(config.DefaultConfig(), io.Discard).Info()).AnyTimes()
+	mockLog.EXPECT().Debug().Return(logger.NewLoggerWithOutput(config.DefaultConfig(), io.Discard).Debug()).AnyTimes()
 
 	mockBus.EXPECT().Publish(gomock.Any()).AnyTimes()
 	mockStore.EXPECT().Phase().Return("").AnyTimes()
@@ -100,4 +101,42 @@ func Test_Server_Start_PortBusy(t *testing.T) {
 	s.Start()
 
 	assert.Nil(t, s.httpServer)
+}
+
+func Test_Server_Start_InvalidListen(t *testing.T) {
+	tests := []struct {
+		name   string
+		listen string
+	}{
+		{
+			name:   "Missing port separator",
+			listen: "not-an-address",
+		},
+		{
+			name:   "Non-numeric port",
+			listen: "127.0.0.1:abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockBus := bus.NewMockBus(ctrl)
+			mockStore := registry.NewMockStore(ctrl)
+			mockLog := logger.NewMockLogger(ctrl)
+
+			mockLog.EXPECT().WithComponent("API").Return(mockLog)
+			mockLog.EXPECT().Warn().Return(logger.NewLoggerWithOutput(config.DefaultConfig(), io.Discard).Warn()).AnyTimes()
+
+			cfg := config.DefaultConfig()
+			cfg.Server.Listen = tt.listen
+
+			s := NewServer(cfg, mockStore, mockBus, mockLog)
+			s.Start()
+
+			assert.Nil(t, s.httpServer)
+		})
+	}
 }

--- a/internal/app/cli/tui.go
+++ b/internal/app/cli/tui.go
@@ -155,7 +155,7 @@ func (t *tui) runWithUI(ctx context.Context, profile string) (int, error) {
 
 	t.writer.SetEnabled(true)
 
-	if runnerErr != nil {
+	if runnerErr != nil && !errors.Is(runnerErr, context.Canceled) {
 		t.log.Error().Err(runnerErr).Msgf("Failed to run profile '%s'", profile)
 		return 1, runnerErr
 	}

--- a/internal/app/cli/tui_test.go
+++ b/internal/app/cli/tui_test.go
@@ -438,6 +438,67 @@ func Test_runWithUI_RunnerErrorQuitsUI(t *testing.T) {
 	assert.Equal(t, runnerErr, runErr)
 }
 
+func Test_runWithUI_UICreationFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRunner := runner.NewMockRunner(ctrl)
+	mockLogger := logger.NewMockLogger(ctrl)
+	mockLogger.EXPECT().Error().Return(nil)
+
+	uiErr := errors.New("ui creation failed")
+
+	tu := &tui{
+		cmd:    &Options{Type: CommandRun, Profile: "test", NoUI: false},
+		runner: mockRunner,
+		log:    mockLogger,
+		writer: newTestWriter(),
+		ui: func(ctx context.Context, profile string) (*tea.Program, error) {
+			return nil, uiErr
+		},
+	}
+
+	exitCode, runErr := tu.runWithUI(context.Background(), "test")
+
+	assert.Equal(t, 1, exitCode)
+	require.Error(t, runErr)
+	assert.Equal(t, uiErr, runErr)
+}
+
+func Test_runWithUI_RunnerContextCanceledOnUIQuit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRunner := runner.NewMockRunner(ctrl)
+	mockLogger := logger.NewMockLogger(ctrl)
+
+	mockRunner.EXPECT().Run(gomock.Any(), "test").DoAndReturn(func(ctx context.Context, profile string) error {
+		<-ctx.Done()
+		return context.Canceled
+	})
+
+	inputR, inputW, err := os.Pipe()
+	require.NoError(t, err)
+	inputW.Close()
+
+	tu := &tui{
+		cmd:    &Options{Type: CommandRun, Profile: "test", NoUI: false},
+		runner: mockRunner,
+		log:    mockLogger,
+		writer: newTestWriter(),
+		ui: func(ctx context.Context, profile string) (*tea.Program, error) {
+			return tea.NewProgram(quitModel{}, tea.WithInput(inputR), tea.WithoutRenderer()), nil
+		},
+	}
+
+	exitCode, runErr := tu.runWithUI(context.Background(), "test")
+
+	inputR.Close()
+
+	assert.Equal(t, 0, exitCode)
+	require.NoError(t, runErr)
+}
+
 func Test_runWithUI_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/internal/app/relay/server.go
+++ b/internal/app/relay/server.go
@@ -183,7 +183,7 @@ func (s *Server) Stop() {
 		s.log.Warn().Err(err).Msgf("Failed to remove socket file: %s", s.socketPath)
 	}
 
-	s.log.Info().Msg("Server stopped")
+	s.log.Debug().Msg("Server stopped")
 }
 
 func (s *Server) acceptConnections(ctx context.Context) {


### PR DESCRIPTION
Fix API and relay shutdown messages to debug so a normal info-level run no longer prints 'API server shutting down', 'API server stopped' and 'Server stopped' on every exit