### PR TITLE
feat(doctor): Add doctor command

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,6 +77,8 @@ graph TD
     end
 ```
 
+Not every command boots the FX container. Utility commands (`init`, `version`, `help`) and the `doctor` diagnostic run standalone in the CLI layer. `doctor` deliberately bypasses FX and loads the config itself so it can report load and validation failures as part of its read-only health report (Environment, Configuration, Services, Topology, Runtime) rather than aborting at startup.
+
 ## 1. Data/Communication Layer
 
 **Package**: `internal/app/bus`

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - **Pre-flight Cleanup** - Automatic detection and termination of orphaned processes before starting services
 - **Hot-Reload** - Automatic service restart on file changes
 - **Log Streaming** - Stream logs from running instances via `fuku logs`
+- **Diagnostics** - Health-check your setup with `fuku doctor` (config, environment, topology, and runtime checks; `--json` for scripting)
 - **REST API** - Control and monitor services via HTTP with token authentication
 - **Update Notifications** - TUI highlights a hint next to the version footer when a newer GitHub release is available (cached 24h, opt out via `FUKU_UPDATER_DISABLED=1`)
 
@@ -70,6 +71,12 @@ fuku stop core                  # Specific profile
 fuku logs                       # All services
 fuku logs api auth              # Specific services
 fuku l api db                   # Short alias
+
+# Diagnose configuration, environment, and runtime issues
+fuku doctor                     # Default profile
+fuku doctor core                # Specific profile
+fuku doctor --summary           # Compact one-line-per-check report
+fuku doctor --json              # Machine-readable report (exit 2 on any failure)
 
 # Use custom config file
 fuku --config path/to/fuku.yaml run core

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,21 +43,21 @@ func runApp() (exitCode int) {
 		return 1
 	}
 
-	cfg, topology, err := loadConfig(cmd.ConfigFile)
+	if cmd.Type == cli.CommandDoctor {
+		return cli.RunDoctor(cmd)
+	}
+
+	cfg, topology, err := config.LoadPath(cmd.ConfigFile)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 
 		return 1
 	}
 
-	switch cmd.Type {
-	case cli.CommandRun, cli.CommandStop:
-		if len(cfg.Services) == 0 {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", errors.ErrNoServicesDefined)
+	if cmd.Type.RequiresServices() && len(cfg.Services) == 0 {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", errors.ErrNoServicesDefined)
 
-			return 1
-		}
-	default:
+		return 1
 	}
 
 	if cfg.Telemetry && cfg.SentryDSN == "" {
@@ -68,15 +68,6 @@ func runApp() (exitCode int) {
 	application.Run()
 
 	return 0
-}
-
-// loadConfig wraps config loading for easier testing
-func loadConfig(configFile string) (*config.Config, *config.Topology, error) {
-	if configFile != "" {
-		return config.LoadFromFile(configFile)
-	}
-
-	return config.Load()
 }
 
 // createAppWithoutConfig creates a lightweight app for standalone commands (init, version, help)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -26,7 +26,7 @@ profiles:
 `
 	require.NoError(t, os.WriteFile("fuku.yaml", []byte(content), 0644))
 
-	cfg, topology, err := loadConfig("")
+	cfg, topology, err := config.LoadPath("")
 	require.NoError(t, err)
 
 	assert.NotNil(t, cfg)
@@ -38,7 +38,7 @@ profiles:
 func Test_LoadConfig_NoConfigFile(t *testing.T) {
 	t.Chdir(t.TempDir())
 
-	cfg, topology, err := loadConfig("")
+	cfg, topology, err := config.LoadPath("")
 	require.NoError(t, err)
 
 	assert.NotNil(t, cfg)
@@ -59,7 +59,7 @@ services:
 	err := os.WriteFile(filePath, []byte(content), 0644)
 	require.NoError(t, err)
 
-	cfg, topology, err := loadConfig(filePath)
+	cfg, topology, err := config.LoadPath(filePath)
 	require.NoError(t, err)
 	assert.NotNil(t, cfg)
 	assert.NotNil(t, topology)
@@ -84,7 +84,7 @@ services:
 	cmd := &cli.Options{ConfigFile: "project/fuku.yaml"}
 	require.NoError(t, cli.ChangeToConfigDir(cmd))
 
-	cfg, topology, err := loadConfig(cmd.ConfigFile)
+	cfg, topology, err := config.LoadPath(cmd.ConfigFile)
 	require.NoError(t, err)
 	assert.NotNil(t, cfg)
 	assert.NotNil(t, topology)
@@ -94,7 +94,7 @@ services:
 func Test_LoadConfig_ExplicitPathNotFound(t *testing.T) {
 	t.Chdir(t.TempDir())
 
-	_, _, err := loadConfig("nonexistent.yaml")
+	_, _, err := config.LoadPath("nonexistent.yaml")
 	require.Error(t, err)
 }
 

--- a/docs/src/pages/docs/cli.astro
+++ b/docs/src/pages/docs/cli.astro
@@ -49,6 +49,11 @@ const nav = getDocsNav(base);
         <td>Stream logs from a running fuku instance</td>
       </tr>
       <tr>
+        <td><code>fuku doctor [profile]</code></td>
+        <td>&mdash;</td>
+        <td>Diagnose configuration, environment, topology, and runtime issues</td>
+      </tr>
+      <tr>
         <td><code>fuku init</code></td>
         <td><code>i</code></td>
         <td>Generate a <code>fuku.yaml</code> template</td>
@@ -81,7 +86,7 @@ const nav = getDocsNav(base);
     <tbody>
       <tr>
         <td><code>--config</code>, <code>-c</code></td>
-        <td>Path to config file (default: <code>fuku.yaml</code>, falls back to <code>fuku.yml</code>). Disables automatic override file merging. Only supported with <code>run</code>, <code>stop</code>, and <code>logs</code> commands</td>
+        <td>Path to config file (default: <code>fuku.yaml</code>, falls back to <code>fuku.yml</code>). Disables automatic override file merging. Supported with <code>run</code>, <code>stop</code>, <code>logs</code>, and <code>doctor</code> commands</td>
       </tr>
       <tr>
         <td><code>--no-ui</code></td>
@@ -90,6 +95,14 @@ const nav = getDocsNav(base);
       <tr>
         <td><code>--profile</code></td>
         <td>Filter by profile (used with <code>logs</code> command)</td>
+      </tr>
+      <tr>
+        <td><code>--summary</code></td>
+        <td>Print a compact one-line-per-check report (used with <code>doctor</code> command)</td>
+      </tr>
+      <tr>
+        <td><code>--json</code></td>
+        <td>Print the report as machine-readable JSON (used with <code>doctor</code> command)</td>
       </tr>
     </tbody>
   </table>
@@ -126,12 +139,65 @@ fuku l api db                   # Short alias
 fuku --config path/to/fuku.yaml run core
 fuku -c custom.yaml run core
 
+# Diagnose configuration, environment, and runtime issues
+fuku doctor                     # Default profile
+fuku doctor core                # Specific profile
+fuku doctor --summary           # Compact one-line-per-check report
+fuku doctor --json              # Machine-readable report
+
 # Generate config template
 fuku init
 
 # Show help / version
 fuku help
 fuku version`} />
+
+  <hr />
+
+  <div class="section-eyebrow">Diagnostics</div>
+  <h2>fuku doctor</h2>
+
+  <p>
+    <code>fuku doctor</code> runs a read-only health check and prints a sectioned
+    report &mdash; <strong>Environment</strong>, <strong>Configuration</strong>,
+    <strong>Services</strong>, <strong>Topology</strong>, and <strong>Runtime</strong>.
+    It diagnoses a broken setup without starting any services, so it works even when
+    the config fails to load. See <a href={`${base}docs/troubleshooting/#diagnostics`}>Troubleshooting</a> for what each section checks.
+  </p>
+
+  <p>Each check carries a status glyph:</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Glyph</th>
+        <th>Meaning</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td><code>✓</code></td><td>ok</td></tr>
+      <tr><td><code>○</code></td><td>idle (inactive but expected)</td></tr>
+      <tr><td><code>↑</code></td><td>note (informational)</td></tr>
+      <tr><td><code>⚠</code></td><td>warning (non-fatal)</td></tr>
+      <tr><td><code>✗</code></td><td>failure</td></tr>
+    </tbody>
+  </table>
+
+  <p>The exit code makes <code>doctor</code> usable in scripts and CI:</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Exit code</th>
+        <th>Meaning</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td><code>0</code></td><td>No failures (warnings and notes are allowed)</td></tr>
+      <tr><td><code>2</code></td><td>At least one check failed</td></tr>
+      <tr><td><code>3</code></td><td>doctor itself errored (e.g. failed to write the JSON report)</td></tr>
+    </tbody>
+  </table>
 
   <hr />
 

--- a/docs/src/pages/docs/troubleshooting.astro
+++ b/docs/src/pages/docs/troubleshooting.astro
@@ -21,6 +21,44 @@ const nav = getDocsNav(base);
   <h1>Troubleshooting</h1>
   <p class="lead">Common issues and practical workarounds.</p>
 
+  <div class="section-eyebrow" id="diagnostics">Diagnostics</div>
+  <h2>Start with <code>fuku doctor</code></h2>
+
+  <p>
+    When something is off, run <code>fuku doctor</code> first. It performs a read-only
+    health check and prints a sectioned report without starting any services, so it
+    works even when the config fails to load:
+  </p>
+
+  <ul>
+    <li><strong>Environment</strong> &mdash; OS/arch, Go runtime, and whether the <code>fuku</code> binary resolves consistently.</li>
+    <li><strong>Configuration</strong> &mdash; the config file was found and parsed, override-file merge status, schema validation, and resolved settings.</li>
+    <li><strong>Services</strong> &mdash; per-service directories, <code>.env</code> files, and readiness configuration.</li>
+    <li><strong>Topology</strong> &mdash; resolved tier order and whether the active profile resolves to a non-empty service list.</li>
+    <li><strong>Runtime</strong> &mdash; other running fuku instances, stale sockets, and readiness ports already bound by another process.</li>
+  </ul>
+
+  <CodeTerminal code={`# Full report for the default profile
+fuku doctor
+
+# Check a specific profile
+fuku doctor core
+
+# Compact one-line-per-check view
+fuku doctor --summary
+
+# Machine-readable output for scripts/CI (exit 2 on any failure)
+fuku doctor --json`} />
+
+  <p>
+    The exit code is <code>0</code> when nothing failed (warnings and notes are fine),
+    <code>2</code> when at least one check failed, and <code>3</code> if doctor itself
+    errored. See the <a href={`${base}docs/cli/#diagnostics`}>CLI reference</a> for the
+    full glyph and exit-code tables.
+  </p>
+
+  <hr />
+
   <div class="section-eyebrow">Hot-reload</div>
   <h2>Hot-reload and branch switching</h2>
 

--- a/e2e/doctor_test.go
+++ b/e2e/doctor_test.go
@@ -1,0 +1,215 @@
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fuku doctor exit codes (mirror internal/app/doctor.Report.ExitCode):
+//   0 — no fails (warns/notes allowed)
+//   2 — at least one fail
+//   3 — doctor itself errored (e.g. RenderJSON write failure)
+
+func Test_Doctor_NoConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	result := RunOnce(t, dir, "doctor")
+
+	assert.Equal(t, 2, result.ExitCode)
+	assert.Contains(t, result.Stdout, "fuku doctor v")
+	assert.Contains(t, result.Stdout, "config.file")
+	assert.Contains(t, result.Stdout, "no fuku.yaml found")
+	assert.Contains(t, result.Stdout, "✗")
+}
+
+func Test_Doctor_ValidConfig_TextReport(t *testing.T) {
+	result := RunOnce(t, "testdata/yml-config", "doctor")
+
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Contains(t, result.Stdout, "Configuration")
+	assert.Contains(t, result.Stdout, "Services")
+	assert.Contains(t, result.Stdout, "Runtime")
+	assert.Contains(t, result.Stdout, "config.file")
+	assert.Contains(t, result.Stdout, "active profile: default")
+}
+
+func Test_Doctor_ValidConfig_Summary(t *testing.T) {
+	result := RunOnce(t, "testdata/yml-config", "doctor", "--summary")
+
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Contains(t, result.Stdout, "config.file")
+	assert.NotContains(t, result.Stdout, "Notes\n")
+	assert.NotContains(t, result.Stdout, "remediation")
+}
+
+func Test_Doctor_ValidConfig_JSON(t *testing.T) {
+	result := RunOnce(t, "testdata/yml-config", "doctor", "--json")
+
+	assert.Equal(t, 0, result.ExitCode)
+
+	var report map[string]any
+	require.NoError(t, json.Unmarshal([]byte(result.Stdout), &report))
+
+	assert.InDelta(t, float64(1), report["schemaVersion"], 0)
+	assert.Contains(t, report, "tally")
+	assert.Contains(t, report, "checks")
+	assert.Contains(t, report, "sections")
+
+	checks, ok := report["checks"].(map[string]any)
+	require.True(t, ok, "checks must be an object")
+	assert.Contains(t, checks, "config.file")
+	assert.Contains(t, checks, "services.directories")
+	assert.Contains(t, checks, "runtime.sockets")
+}
+
+func Test_Doctor_InvalidYAML_Fails(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "fuku.yaml"), []byte("services: [unterminated"), 0o600))
+
+	result := RunOnce(t, dir, "doctor")
+
+	assert.Equal(t, 2, result.ExitCode)
+	assert.Contains(t, result.Stdout, "config.file")
+	assert.Contains(t, result.Stdout, "failed to load")
+}
+
+func Test_Doctor_InvalidSchema_Fails(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "api"), 0o755))
+
+	// parses as YAML but fails schema validation (unknown readiness type)
+	yaml := `version: 1
+
+services:
+  api:
+    dir: api
+    readiness:
+      type: bogus
+      url: http://localhost:8080
+profiles:
+  default: "*"
+`
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "fuku.yaml"), []byte(yaml), 0o600))
+
+	result := RunOnce(t, dir, "doctor")
+
+	assert.Equal(t, 2, result.ExitCode)
+	assert.Contains(t, result.Stdout, "config.validate")
+	assert.Contains(t, result.Stdout, "schema validation failed")
+	// the file parsed fine, so config.file must not claim a load failure
+	assert.Contains(t, result.Stdout, "found and parsed")
+	assert.NotContains(t, result.Stdout, "failed to load")
+}
+
+func Test_Doctor_MissingServiceDir_Warns(t *testing.T) {
+	dir := t.TempDir()
+
+	yaml := `version: 1
+
+services:
+  api:
+    dir: nonexistent-api
+profiles:
+  default: "*"
+`
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "fuku.yaml"), []byte(yaml), 0o600))
+
+	result := RunOnce(t, dir, "doctor")
+
+	assert.Equal(t, 0, result.ExitCode, "missing dir is a warn, not a fail")
+	assert.Contains(t, result.Stdout, "services.directories")
+	assert.Contains(t, result.Stdout, "MISSING")
+	assert.Contains(t, result.Stdout, "⚠")
+}
+
+func Test_Doctor_MalformedHTTPURL_Fails(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "api"), 0o755))
+
+	yaml := `version: 1
+
+services:
+  api:
+    dir: api
+    readiness:
+      type: http
+      url: "localhost:8080/health"
+profiles:
+  default: "*"
+`
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "fuku.yaml"), []byte(yaml), 0o600))
+
+	result := RunOnce(t, dir, "doctor")
+
+	assert.Equal(t, 2, result.ExitCode)
+	assert.Contains(t, result.Stdout, "services.readiness")
+	assert.Contains(t, result.Stdout, "scheme must be http or https")
+}
+
+func Test_Doctor_ExplicitConfig_OverrideSkipped(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "api"), 0o755))
+
+	base := `version: 1
+
+services:
+  api:
+    dir: api
+profiles:
+  default: "*"
+`
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "fuku.yaml"), []byte(base), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "fuku.override.yaml"), []byte("logging:\n  level: debug\n"), 0o600))
+
+	result := RunOnce(t, dir, "--config", "fuku.yaml", "doctor")
+
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Contains(t, result.Stdout, "config.override")
+	assert.Contains(t, result.Stdout, "override file present but skipped")
+	assert.NotContains(t, result.Stdout, "override applied")
+}
+
+func Test_Doctor_DefaultLoad_OverrideApplied(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "api"), 0o755))
+
+	base := `version: 1
+
+services:
+  api:
+    dir: api
+profiles:
+  default: "*"
+`
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "fuku.yaml"), []byte(base), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "fuku.override.yaml"), []byte("logging:\n  level: debug\n"), 0o600))
+
+	result := RunOnce(t, dir, "doctor")
+
+	assert.Equal(t, 0, result.ExitCode)
+	assert.Contains(t, result.Stdout, "config.override")
+	assert.Contains(t, result.Stdout, "override applied")
+}
+
+func Test_Doctor_StaleSocketRemediation_NoFixFlag(t *testing.T) {
+	// regression: doctor must not advertise a `--fix` flag that doesn't exist
+	result := RunOnce(t, "testdata/yml-config", "doctor")
+	assert.NotContains(t, result.Stdout, "doctor --fix")
+}
+
+func Test_Doctor_UnknownProfile_Fails(t *testing.T) {
+	result := RunOnce(t, "testdata/yml-config", "doctor", "no-such-profile")
+
+	assert.Equal(t, 2, result.ExitCode)
+	assert.Contains(t, result.Stdout, "no-such-profile")
+}

--- a/internal/app/cli/cli.go
+++ b/internal/app/cli/cli.go
@@ -1,10 +1,12 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"fuku/internal/app/doctor"
 	"fuku/internal/app/errors"
 	"fuku/internal/config"
 	"fuku/internal/config/template"
@@ -28,6 +30,10 @@ const (
   fuku logs [service...]          Stream logs from running services
   fuku --logs                     Same as above (--logs, -l, logs, l)
   fuku logs --profile <name> [service...] Stream logs from specific profile
+
+  fuku doctor [profile]           Diagnose configuration, environment, and runtime issues
+  fuku doctor --summary           Print a compact one-line-per-check report
+  fuku doctor --json              Print the report as JSON
 
   fuku --config <path>            Use custom config file, skip override merging (--config, -c)
 
@@ -97,6 +103,28 @@ func ChangeToConfigDir(cmd *Options) error {
 	cmd.ConfigFile = filepath.Base(cmd.ConfigFile)
 
 	return nil
+}
+
+// RunDoctor executes the doctor command and writes the report to stdout
+func RunDoctor(cmd *Options) int {
+	report := doctor.Run(context.Background(), doctor.Options{
+		Profile:    cmd.Profile,
+		ConfigPath: cmd.ConfigFile,
+	})
+
+	switch cmd.DoctorFormat {
+	case DoctorFormatJSON:
+		if err := doctor.RenderJSON(os.Stdout, report); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 3
+		}
+	case DoctorFormatSummary:
+		doctor.RenderSummary(os.Stdout, report)
+	default:
+		doctor.RenderText(os.Stdout, report)
+	}
+
+	return report.ExitCode()
 }
 
 // GenerateConfigFile creates a fuku.yaml template in the current directory

--- a/internal/app/cli/cli_test.go
+++ b/internal/app/cli/cli_test.go
@@ -70,6 +70,59 @@ func Test_CLI_Run(t *testing.T) {
 	}
 }
 
+func Test_RunDoctor(t *testing.T) {
+	tests := []struct {
+		name         string
+		cmd          *Options
+		expectedExit int
+		contains     string
+	}{
+		{
+			name:         "no config text mode fails",
+			cmd:          &Options{Type: CommandDoctor, Profile: config.Default, DoctorFormat: DoctorFormatText},
+			expectedExit: 2,
+			contains:     "fuku doctor",
+		},
+		{
+			name:         "no config json mode fails with json output",
+			cmd:          &Options{Type: CommandDoctor, Profile: config.Default, DoctorFormat: DoctorFormatJSON},
+			expectedExit: 2,
+			contains:     `"overallStatus":`,
+		},
+		{
+			name:         "no config summary mode fails with summary output",
+			cmd:          &Options{Type: CommandDoctor, Profile: config.Default, DoctorFormat: DoctorFormatSummary},
+			expectedExit: 2,
+			contains:     "fuku doctor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+
+			oldStdout := os.Stdout
+			r, w, err := os.Pipe()
+			require.NoError(t, err)
+
+			os.Stdout = w
+
+			exitCode := RunDoctor(tt.cmd)
+
+			w.Close()
+
+			os.Stdout = oldStdout
+
+			var buf bytes.Buffer
+
+			_, _ = io.Copy(&buf, r)
+
+			assert.Equal(t, tt.expectedExit, exitCode)
+			assert.Contains(t, buf.String(), tt.contains)
+		})
+	}
+}
+
 func Test_GenerateConfigFile(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/app/cli/commands.go
+++ b/internal/app/cli/commands.go
@@ -18,12 +18,23 @@ const (
 	CommandLogs
 	CommandVersion
 	CommandHelp
+	CommandDoctor
 )
 
 // Standalone returns true for commands that run without config or FX container
 func (c CommandType) Standalone() bool {
 	switch c {
 	case CommandInit, CommandVersion, CommandHelp:
+		return true
+	default:
+		return false
+	}
+}
+
+// RequiresServices returns true for commands that need at least one service defined in the config
+func (c CommandType) RequiresServices() bool {
+	switch c {
+	case CommandRun, CommandStop:
 		return true
 	default:
 		return false
@@ -45,18 +56,31 @@ func (c CommandType) String() string {
 		return "version"
 	case CommandHelp:
 		return "help"
+	case CommandDoctor:
+		return "doctor"
 	default:
 		return "unknown"
 	}
 }
 
+// DoctorFormat selects the doctor renderer
+type DoctorFormat int
+
+// DoctorFormat values
+const (
+	DoctorFormatText DoctorFormat = iota
+	DoctorFormatSummary
+	DoctorFormatJSON
+)
+
 // Options contains the parsed command-line arguments
 type Options struct {
-	ConfigFile string
-	Type       CommandType
-	Profile    string
-	Services   []string
-	NoUI       bool
+	ConfigFile   string
+	Type         CommandType
+	Profile      string
+	Services     []string
+	NoUI         bool
+	DoctorFormat DoctorFormat
 }
 
 // rootFlags holds flag values for the root command
@@ -84,6 +108,7 @@ func Parse(args []string) (*Options, error) {
 		buildStopCommand(result),
 		buildLogsCommand(result),
 		buildVersionCommand(result),
+		buildDoctorCommand(result),
 	)
 
 	root.SetArgs(args)
@@ -232,6 +257,41 @@ func buildVersionCommand(result *Options) *cobra.Command {
 			result.Type = CommandVersion
 		},
 	}
+
+	return cmd
+}
+
+// buildDoctorCommand creates the doctor subcommand
+func buildDoctorCommand(result *Options) *cobra.Command {
+	var (
+		summary bool
+		asJSON  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "doctor [profile]",
+		Short: "Diagnose configuration, environment, and runtime issues",
+		Args:  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			result.Type = CommandDoctor
+
+			if len(args) > 0 {
+				result.Profile = args[0]
+			}
+
+			switch {
+			case asJSON:
+				result.DoctorFormat = DoctorFormatJSON
+			case summary:
+				result.DoctorFormat = DoctorFormatSummary
+			default:
+				result.DoctorFormat = DoctorFormatText
+			}
+		},
+	}
+
+	cmd.Flags().BoolVar(&summary, "summary", false, "Print a compact one-line-per-check report")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Print the report as JSON")
 
 	return cmd
 }

--- a/internal/app/cli/commands_test.go
+++ b/internal/app/cli/commands_test.go
@@ -282,6 +282,30 @@ func Test_Parse(t *testing.T) {
 			expectedNoUI:       false,
 			expectedConfigFile: "other.yaml",
 		},
+		{
+			name:            "doctor command",
+			args:            []string{"doctor"},
+			expectedType:    CommandDoctor,
+			expectedProfile: config.Default,
+		},
+		{
+			name:            "doctor command with profile",
+			args:            []string{"doctor", "core"},
+			expectedType:    CommandDoctor,
+			expectedProfile: "core",
+		},
+		{
+			name:            "doctor --summary",
+			args:            []string{"doctor", "--summary"},
+			expectedType:    CommandDoctor,
+			expectedProfile: config.Default,
+		},
+		{
+			name:            "doctor --json",
+			args:            []string{"doctor", "--json"},
+			expectedType:    CommandDoctor,
+			expectedProfile: config.Default,
+		},
 	}
 
 	for _, tt := range tests {
@@ -335,11 +359,56 @@ func Test_CommandType_Standalone(t *testing.T) {
 			cmd:      CommandLogs,
 			expected: false,
 		},
+		{
+			name:     "doctor is not standalone",
+			cmd:      CommandDoctor,
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.cmd.Standalone())
+		})
+	}
+}
+
+func Test_CommandType_RequiresServices(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      CommandType
+		expected bool
+	}{
+		{
+			name:     "run requires services",
+			cmd:      CommandRun,
+			expected: true,
+		},
+		{
+			name:     "stop requires services",
+			cmd:      CommandStop,
+			expected: true,
+		},
+		{
+			name:     "doctor does not require services",
+			cmd:      CommandDoctor,
+			expected: false,
+		},
+		{
+			name:     "logs does not require services",
+			cmd:      CommandLogs,
+			expected: false,
+		},
+		{
+			name:     "init does not require services",
+			cmd:      CommandInit,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.cmd.RequiresServices())
 		})
 	}
 }

--- a/internal/app/doctor/checks.go
+++ b/internal/app/doctor/checks.go
@@ -1,0 +1,27 @@
+package doctor
+
+import (
+	"os"
+	"time"
+)
+
+// timed records the duration of fn into the returned result
+func timed(fn func() Result) Result {
+	start := time.Now()
+	r := fn()
+	r.DurationMs = time.Since(start).Milliseconds()
+
+	return r
+}
+
+// fileExists reports whether path refers to an existing file
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// dirExists reports whether path exists and is a directory
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/internal/app/doctor/checks_test.go
+++ b/internal/app/doctor/checks_test.go
@@ -1,0 +1,57 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_timed(t *testing.T) {
+	r := timed(func() Result {
+		return Result{ID: "x", Status: StatusOK}
+	})
+
+	assert.Equal(t, "x", r.ID)
+	assert.GreaterOrEqual(t, r.DurationMs, int64(0))
+}
+
+func Test_fileExists(t *testing.T) {
+	dir := t.TempDir()
+
+	filePath := filepath.Join(dir, "real.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte(""), 0600))
+
+	subDir := filepath.Join(dir, "subdir")
+	require.NoError(t, os.MkdirAll(subDir, 0755))
+
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "existing file",
+			path:     filePath,
+			expected: true,
+		},
+		{
+			name:     "directory returns false",
+			path:     subDir,
+			expected: false,
+		},
+		{
+			name:     "missing path",
+			path:     filepath.Join(dir, "missing.txt"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, fileExists(tt.path))
+		})
+	}
+}

--- a/internal/app/doctor/config.go
+++ b/internal/app/doctor/config.go
@@ -1,0 +1,181 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"fuku/internal/app/errors"
+)
+
+// configSection collects config-file and validation checks
+func configSection(_ context.Context, env *Env) Section {
+	return Section{
+		Title: "Configuration",
+		Results: []Result{
+			timed(func() Result { return checkConfigFile(env) }),
+			timed(func() Result { return checkConfigOverride(env) }),
+			timed(func() Result { return checkConfigValidate(env) }),
+			timed(func() Result { return checkConfigSettings(env) }),
+		},
+	}
+}
+
+// checkConfigFile reports whether the base config file was found and loaded
+func checkConfigFile(env *Env) Result {
+	if env.ConfigPath == "" {
+		return Result{
+			ID:          "config.file",
+			Category:    "configuration",
+			Status:      StatusFail,
+			Summary:     "no fuku.yaml found in current directory",
+			Remediation: "run `fuku init` to generate a template",
+		}
+	}
+
+	// A schema-validation failure means the file was found, read, and parsed; that
+	// is reported by config.validate, so this check only flags read/parse failures.
+	if env.LoadErr != nil && !errors.Is(env.LoadErr, errors.ErrInvalidConfig) {
+		return Result{
+			ID:       "config.file",
+			Category: "configuration",
+			Status:   StatusFail,
+			Summary:  "failed to load " + env.ConfigPath,
+			Details: []Detail{
+				{Key: "path", Value: env.ConfigPath},
+				{Key: "error", Value: env.LoadErr.Error()},
+			},
+			Remediation: "check YAML syntax and required fields",
+		}
+	}
+
+	return Result{
+		ID:       "config.file",
+		Category: "configuration",
+		Status:   StatusOK,
+		Summary:  "found and parsed",
+		Details: []Detail{
+			{Key: "path", Value: env.ConfigPath},
+		},
+	}
+}
+
+// checkConfigOverride reports whether an override file is present and whether it was merged
+func checkConfigOverride(env *Env) Result {
+	if env.OverridePath == "" {
+		return Result{
+			ID:       "config.override",
+			Category: "configuration",
+			Status:   StatusIdle,
+			Summary:  "no override file present",
+		}
+	}
+
+	if env.ExplicitConfig {
+		return Result{
+			ID:       "config.override",
+			Category: "configuration",
+			Status:   StatusNote,
+			Summary:  "override file present but skipped (--config bypasses overrides)",
+			Details: []Detail{
+				{Key: "path", Value: env.OverridePath},
+			},
+		}
+	}
+
+	if env.LoadErr != nil {
+		return Result{
+			ID:       "config.override",
+			Category: "configuration",
+			Status:   StatusIdle,
+			Summary:  "override merge status unknown (config did not load)",
+			Details: []Detail{
+				{Key: "path", Value: env.OverridePath},
+			},
+		}
+	}
+
+	return Result{
+		ID:       "config.override",
+		Category: "configuration",
+		Status:   StatusOK,
+		Summary:  "override applied",
+		Details: []Detail{
+			{Key: "path", Value: env.OverridePath},
+		},
+	}
+}
+
+// checkConfigValidate reports the result of schema validation
+func checkConfigValidate(env *Env) Result {
+	// Load() validates internally and returns a nil Config with ErrInvalidConfig on
+	// failure, so a validation error arrives via LoadErr rather than env.Config.
+	if errors.Is(env.LoadErr, errors.ErrInvalidConfig) {
+		return invalidConfigResult(env.LoadErr)
+	}
+
+	if env.Config == nil {
+		return Result{
+			ID:       "config.validate",
+			Category: "configuration",
+			Status:   StatusIdle,
+			Summary:  "skipped (config did not load)",
+		}
+	}
+
+	if err := env.Config.Validate(); err != nil {
+		return invalidConfigResult(err)
+	}
+
+	return Result{
+		ID:       "config.validate",
+		Category: "configuration",
+		Status:   StatusOK,
+		Summary:  "schema ok",
+	}
+}
+
+// invalidConfigResult builds the config.validate failure result for a schema error
+func invalidConfigResult(err error) Result {
+	return Result{
+		ID:       "config.validate",
+		Category: "configuration",
+		Status:   StatusFail,
+		Summary:  "schema validation failed",
+		Details: []Detail{
+			{Key: "error", Value: err.Error()},
+		},
+		Remediation: "fix the offending field in fuku.yaml",
+	}
+}
+
+// checkConfigSettings reports concurrency, retry, and log buffer settings
+func checkConfigSettings(env *Env) Result {
+	if env.Config == nil {
+		return Result{
+			ID:       "config.settings",
+			Category: "configuration",
+			Status:   StatusIdle,
+			Summary:  "skipped (config did not load)",
+		}
+	}
+
+	cfg := env.Config
+
+	return Result{
+		ID:       "config.settings",
+		Category: "configuration",
+		Status:   StatusOK,
+		Summary: fmt.Sprintf("workers=%d retry=%d backoff=%s",
+			cfg.Concurrency.Workers, cfg.Retry.Attempts, cfg.Retry.Backoff),
+		Details: []Detail{
+			{Key: "concurrency workers", Value: strconv.Itoa(cfg.Concurrency.Workers)},
+			{Key: "retry attempts", Value: strconv.Itoa(cfg.Retry.Attempts)},
+			{Key: "retry backoff", Value: cfg.Retry.Backoff.String()},
+			{Key: "logs buffer", Value: strconv.Itoa(cfg.Logs.Buffer)},
+			{Key: "logs history", Value: strconv.Itoa(cfg.Logs.History)},
+			{Key: "logging level", Value: cfg.Logging.Level},
+			{Key: "logging format", Value: cfg.Logging.Format},
+		},
+	}
+}

--- a/internal/app/doctor/config_test.go
+++ b/internal/app/doctor/config_test.go
@@ -1,0 +1,178 @@
+package doctor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fuku/internal/app/errors"
+	"fuku/internal/config"
+)
+
+func Test_checkConfigFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      *Env
+		expected Status
+	}{
+		{
+			name:     "missing config",
+			env:      &Env{},
+			expected: StatusFail,
+		},
+		{
+			name: "read or parse error",
+			env: &Env{
+				ConfigPath: "fuku.yaml",
+				LoadErr:    assert.AnError,
+			},
+			expected: StatusFail,
+		},
+		{
+			name: "validation error is not a load failure",
+			env: &Env{
+				ConfigPath: "fuku.yaml",
+				LoadErr:    errors.ErrInvalidConfig,
+			},
+			expected: StatusOK,
+		},
+		{
+			name: "loaded ok",
+			env: &Env{
+				ConfigPath: "fuku.yaml",
+				Config:     config.DefaultConfig(),
+			},
+			expected: StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := checkConfigFile(tt.env)
+
+			assert.Equal(t, tt.expected, r.Status)
+			assert.Equal(t, "config.file", r.ID)
+		})
+	}
+}
+
+func Test_checkConfigOverride(t *testing.T) {
+	tests := []struct {
+		name            string
+		env             *Env
+		expectedStatus  Status
+		expectedSummary string
+	}{
+		{
+			name:            "no override file",
+			env:             &Env{},
+			expectedStatus:  StatusIdle,
+			expectedSummary: "no override file present",
+		},
+		{
+			name: "override applied with default load",
+			env: &Env{
+				OverridePath: "fuku.override.yaml",
+				Config:       config.DefaultConfig(),
+			},
+			expectedStatus:  StatusOK,
+			expectedSummary: "override applied",
+		},
+		{
+			name: "explicit config bypasses override",
+			env: &Env{
+				OverridePath:   "fuku.override.yaml",
+				Config:         config.DefaultConfig(),
+				ExplicitConfig: true,
+			},
+			expectedStatus:  StatusNote,
+			expectedSummary: "override file present but skipped (--config bypasses overrides)",
+		},
+		{
+			name: "load error with override present is unknown",
+			env: &Env{
+				OverridePath: "fuku.override.yaml",
+				LoadErr:      assert.AnError,
+			},
+			expectedStatus:  StatusIdle,
+			expectedSummary: "override merge status unknown (config did not load)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := checkConfigOverride(tt.env)
+
+			assert.Equal(t, tt.expectedStatus, r.Status)
+			assert.Equal(t, tt.expectedSummary, r.Summary)
+		})
+	}
+}
+
+func Test_checkConfigValidate(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      *Env
+		expected Status
+	}{
+		{
+			name:     "config did not load skips as idle",
+			env:      &Env{LoadErr: assert.AnError},
+			expected: StatusIdle,
+		},
+		{
+			name:     "validation error from load reports fail",
+			env:      &Env{LoadErr: errors.ErrInvalidConfig},
+			expected: StatusFail,
+		},
+		{
+			name: "valid config",
+			env: &Env{
+				Config: config.DefaultConfig(),
+			},
+			expected: StatusOK,
+		},
+		{
+			name: "invalid config supplied directly",
+			env: &Env{
+				Config: &config.Config{
+					Concurrency: config.Concurrency{Workers: 0},
+				},
+			},
+			expected: StatusFail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := checkConfigValidate(tt.env)
+			assert.Equal(t, tt.expected, r.Status)
+		})
+	}
+}
+
+func Test_checkConfigSettings(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      *Env
+		expected Status
+	}{
+		{
+			name:     "config nil reports idle",
+			env:      &Env{},
+			expected: StatusIdle,
+		},
+		{
+			name:     "default config reports ok",
+			env:      &Env{Config: config.DefaultConfig()},
+			expected: StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := checkConfigSettings(tt.env)
+			assert.Equal(t, tt.expected, r.Status)
+		})
+	}
+}

--- a/internal/app/doctor/doctor.go
+++ b/internal/app/doctor/doctor.go
@@ -1,0 +1,158 @@
+// Package doctor diagnoses configuration, environment, and runtime issues for fuku
+package doctor
+
+import "time"
+
+// Status is the result status of a single check
+type Status int
+
+// Status values, ordered by severity from healthy to fatal
+const (
+	StatusOK   Status = iota // ok
+	StatusIdle               // inactive but expected
+	StatusNote               // informational
+	StatusWarn               // non-fatal issue
+	StatusFail               // fatal issue
+)
+
+// String returns the lowercase name of a Status (used in JSON output)
+func (s Status) String() string {
+	switch s {
+	case StatusOK:
+		return "ok"
+	case StatusIdle:
+		return "idle"
+	case StatusNote:
+		return "note"
+	case StatusWarn:
+		return "warn"
+	case StatusFail:
+		return "fail"
+	default:
+		return "unknown"
+	}
+}
+
+// Glyph returns the single-character indicator for a Status
+func (s Status) Glyph() string {
+	switch s {
+	case StatusOK:
+		return "✓"
+	case StatusIdle:
+		return "○"
+	case StatusNote:
+		return "↑"
+	case StatusWarn:
+		return "⚠"
+	case StatusFail:
+		return "✗"
+	default:
+		return "?"
+	}
+}
+
+// Detail is a key-value pair shown in the indented detail block of a result
+type Detail struct {
+	Key   string
+	Value string
+}
+
+// Result is the outcome of a single check
+type Result struct {
+	ID          string
+	Category    string
+	Status      Status
+	Summary     string
+	Details     []Detail
+	Remediation string
+	DurationMs  int64
+}
+
+// Section groups results under a category heading
+type Section struct {
+	Title   string
+	Note    string
+	Results []Result
+}
+
+// Report is the full output of a doctor run
+type Report struct {
+	SchemaVersion int
+	GeneratedAt   time.Time
+	FukuVersion   string
+	Platform      string
+	Sections      []Section
+}
+
+// Tally aggregates result counts by status
+type Tally struct {
+	OK   int
+	Idle int
+	Note int
+	Warn int
+	Fail int
+}
+
+// Tally counts results by status across all sections
+func (r *Report) Tally() Tally {
+	var t Tally
+
+	for _, s := range r.Sections {
+		for _, res := range s.Results {
+			switch res.Status {
+			case StatusOK:
+				t.OK++
+			case StatusIdle:
+				t.Idle++
+			case StatusNote:
+				t.Note++
+			case StatusWarn:
+				t.Warn++
+			case StatusFail:
+				t.Fail++
+			}
+		}
+	}
+
+	return t
+}
+
+// OverallStatus returns the worst status across the whole report
+func (r *Report) OverallStatus() Status {
+	t := r.Tally()
+
+	switch {
+	case t.Fail > 0:
+		return StatusFail
+	case t.Warn > 0:
+		return StatusWarn
+	case t.Note > 0:
+		return StatusNote
+	default:
+		return StatusOK
+	}
+}
+
+// ExitCode returns the process exit code for the report (0=ok or warn, 2=fail)
+func (r *Report) ExitCode() int {
+	if r.Tally().Fail > 0 {
+		return 2
+	}
+
+	return 0
+}
+
+// Notes returns the non-OK results across all sections, in display order
+func (r *Report) Notes() []Result {
+	var notes []Result
+
+	for _, s := range r.Sections {
+		for _, res := range s.Results {
+			if res.Status != StatusOK && res.Status != StatusIdle {
+				notes = append(notes, res)
+			}
+		}
+	}
+
+	return notes
+}

--- a/internal/app/doctor/doctor_test.go
+++ b/internal/app/doctor/doctor_test.go
@@ -1,0 +1,224 @@
+package doctor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Status_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   Status
+		expected string
+	}{
+		{
+			name:     "ok",
+			status:   StatusOK,
+			expected: "ok",
+		},
+		{
+			name:     "idle",
+			status:   StatusIdle,
+			expected: "idle",
+		},
+		{
+			name:     "note",
+			status:   StatusNote,
+			expected: "note",
+		},
+		{
+			name:     "warn",
+			status:   StatusWarn,
+			expected: "warn",
+		},
+		{
+			name:     "fail",
+			status:   StatusFail,
+			expected: "fail",
+		},
+		{
+			name:     "unknown",
+			status:   Status(99),
+			expected: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.status.String())
+		})
+	}
+}
+
+func Test_Status_Glyph(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   Status
+		expected string
+	}{
+		{
+			name:     "ok",
+			status:   StatusOK,
+			expected: "✓",
+		},
+		{
+			name:     "idle",
+			status:   StatusIdle,
+			expected: "○",
+		},
+		{
+			name:     "note",
+			status:   StatusNote,
+			expected: "↑",
+		},
+		{
+			name:     "warn",
+			status:   StatusWarn,
+			expected: "⚠",
+		},
+		{
+			name:     "fail",
+			status:   StatusFail,
+			expected: "✗",
+		},
+		{
+			name:     "unknown",
+			status:   Status(99),
+			expected: "?",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.status.Glyph())
+		})
+	}
+}
+
+func Test_Report_Tally(t *testing.T) {
+	report := &Report{
+		Sections: []Section{
+			{Results: []Result{
+				{Status: StatusOK},
+				{Status: StatusOK},
+				{Status: StatusWarn},
+			}},
+			{Results: []Result{
+				{Status: StatusFail},
+				{Status: StatusIdle},
+				{Status: StatusNote},
+			}},
+		},
+	}
+
+	tally := report.Tally()
+
+	assert.Equal(t, 2, tally.OK)
+	assert.Equal(t, 1, tally.Idle)
+	assert.Equal(t, 1, tally.Note)
+	assert.Equal(t, 1, tally.Warn)
+	assert.Equal(t, 1, tally.Fail)
+}
+
+func Test_Report_OverallStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		results  []Result
+		expected Status
+	}{
+		{
+			name:     "all ok",
+			results:  []Result{{Status: StatusOK}, {Status: StatusOK}},
+			expected: StatusOK,
+		},
+		{
+			name:     "with idle",
+			results:  []Result{{Status: StatusOK}, {Status: StatusIdle}},
+			expected: StatusOK,
+		},
+		{
+			name:     "with note",
+			results:  []Result{{Status: StatusOK}, {Status: StatusNote}},
+			expected: StatusNote,
+		},
+		{
+			name:     "with warn",
+			results:  []Result{{Status: StatusOK}, {Status: StatusWarn}, {Status: StatusNote}},
+			expected: StatusWarn,
+		},
+		{
+			name:     "with fail",
+			results:  []Result{{Status: StatusOK}, {Status: StatusWarn}, {Status: StatusFail}},
+			expected: StatusFail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &Report{Sections: []Section{{Results: tt.results}}}
+			assert.Equal(t, tt.expected, report.OverallStatus())
+		})
+	}
+}
+
+func Test_Report_ExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		results  []Result
+		expected int
+	}{
+		{
+			name:     "all ok",
+			results:  []Result{{Status: StatusOK}},
+			expected: 0,
+		},
+		{
+			name:     "with warn but no fail",
+			results:  []Result{{Status: StatusWarn}},
+			expected: 0,
+		},
+		{
+			name:     "with fail",
+			results:  []Result{{Status: StatusFail}},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &Report{Sections: []Section{{Results: tt.results}}}
+			assert.Equal(t, tt.expected, report.ExitCode())
+		})
+	}
+}
+
+func Test_Report_Notes(t *testing.T) {
+	report := &Report{
+		Sections: []Section{
+			{Results: []Result{
+				{ID: "a", Status: StatusOK},
+				{ID: "b", Status: StatusIdle},
+				{ID: "c", Status: StatusWarn},
+			}},
+			{Results: []Result{
+				{ID: "d", Status: StatusFail},
+				{ID: "e", Status: StatusNote},
+			}},
+		},
+	}
+
+	notes := report.Notes()
+
+	assert.Len(t, notes, 3)
+	assert.Equal(t, "c", notes[0].ID)
+	assert.Equal(t, "d", notes[1].ID)
+	assert.Equal(t, "e", notes[2].ID)
+}
+
+func Test_Report_GeneratedAt(t *testing.T) {
+	report := &Report{GeneratedAt: time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)}
+
+	assert.Equal(t, "2026-06-06T12:00:00Z", report.GeneratedAt.Format("2006-01-02T15:04:05Z"))
+}

--- a/internal/app/doctor/environment.go
+++ b/internal/app/doctor/environment.go
@@ -1,0 +1,91 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// environmentSection collects environment and toolchain checks
+func environmentSection(_ context.Context, _ *Env) Section {
+	return Section{
+		Title: "Environment",
+		Results: []Result{
+			timed(checkSystem),
+			timed(checkRuntime),
+			timed(checkInstall),
+		},
+	}
+}
+
+// checkSystem reports basic OS and locale information (always OK)
+func checkSystem() Result {
+	return Result{
+		ID:       "system",
+		Category: "environment",
+		Status:   StatusOK,
+		Summary:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		Details: []Detail{
+			{Key: "os", Value: runtime.GOOS},
+			{Key: "arch", Value: runtime.GOARCH},
+			{Key: "shell", Value: os.Getenv("SHELL")},
+			{Key: "LANG", Value: envOrDash("LANG")},
+		},
+	}
+}
+
+// checkRuntime reports the active Go runtime version
+func checkRuntime() Result {
+	return Result{
+		ID:       "runtime",
+		Category: "environment",
+		Status:   StatusOK,
+		Summary:  runtime.Version(),
+		Details: []Detail{
+			{Key: "go version", Value: runtime.Version()},
+			{Key: "GOOS", Value: runtime.GOOS},
+			{Key: "GOARCH", Value: runtime.GOARCH},
+		},
+	}
+}
+
+// checkInstall reports the resolved fuku executable path
+func checkInstall() Result {
+	exe, exeErr := os.Executable()
+	if exeErr != nil {
+		return Result{
+			ID:          "install",
+			Category:    "environment",
+			Status:      StatusWarn,
+			Summary:     "could not resolve fuku executable",
+			Remediation: "ensure fuku binary is reachable on PATH",
+		}
+	}
+
+	details := []Detail{
+		{Key: "executable", Value: exe},
+	}
+
+	if pathExe, err := exec.LookPath("fuku"); err == nil {
+		details = append(details, Detail{Key: "PATH fuku", Value: pathExe})
+	}
+
+	return Result{
+		ID:       "install",
+		Category: "environment",
+		Status:   StatusOK,
+		Summary:  "installation looks consistent",
+		Details:  details,
+	}
+}
+
+// envOrDash returns the env var value or "-" when unset
+func envOrDash(key string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+
+	return "-"
+}

--- a/internal/app/doctor/environment_test.go
+++ b/internal/app/doctor/environment_test.go
@@ -1,0 +1,19 @@
+package doctor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_environmentSection(t *testing.T) {
+	section := environmentSection(context.Background(), &Env{})
+
+	assert.Equal(t, "Environment", section.Title)
+	require.Len(t, section.Results, 3)
+	assert.Equal(t, "system", section.Results[0].ID)
+	assert.Equal(t, "runtime", section.Results[1].ID)
+	assert.Equal(t, "install", section.Results[2].ID)
+}

--- a/internal/app/doctor/render.go
+++ b/internal/app/doctor/render.go
@@ -1,0 +1,227 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"fuku/internal/app/ui/components"
+)
+
+const (
+	divider        = "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"
+	idColumnWidth  = 12
+	detailKeyWidth = 25
+)
+
+// RenderText writes the verbose grouped report to w
+func RenderText(w io.Writer, r *Report) {
+	writeHeader(w, r)
+	writeNotes(w, r)
+
+	for _, section := range r.Sections {
+		writeSection(w, section, true)
+	}
+
+	writeFooter(w, r)
+}
+
+// RenderSummary writes a compact one-line-per-check report to w
+func RenderSummary(w io.Writer, r *Report) {
+	writeHeader(w, r)
+
+	for _, section := range r.Sections {
+		writeSection(w, section, false)
+	}
+
+	writeFooter(w, r)
+}
+
+// RenderJSON writes a machine-readable JSON report to w
+func RenderJSON(w io.Writer, r *Report) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	return enc.Encode(toJSONReport(r))
+}
+
+// writeHeader prints the title line and a blank line
+func writeHeader(w io.Writer, r *Report) {
+	fmt.Fprintf(w, "fuku doctor v%s · %s\n\n", r.FukuVersion, r.Platform)
+}
+
+// writeNotes prints the highlighted non-OK results at the top of the report
+func writeNotes(w io.Writer, r *Report) {
+	notes := r.Notes()
+	if len(notes) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w, "Notes")
+
+	for _, res := range notes {
+		fmt.Fprintf(w, "   %s %s %s\n", styledGlyph(res.Status), padRight(res.ID, idColumnWidth), res.Summary)
+	}
+
+	fmt.Fprintln(w, divider)
+}
+
+// writeSection prints a section header and its results
+func writeSection(w io.Writer, s Section, withDetails bool) {
+	if len(s.Results) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w)
+
+	if s.Note != "" {
+		fmt.Fprintf(w, "%s · %s\n", s.Title, s.Note)
+	} else {
+		fmt.Fprintln(w, s.Title)
+	}
+
+	for _, res := range s.Results {
+		writeResult(w, res, withDetails)
+	}
+}
+
+// writeResult prints a single result row and its optional indented details
+func writeResult(w io.Writer, res Result, withDetails bool) {
+	fmt.Fprintf(w, "  %s %s %s\n", styledGlyph(res.Status), padRight(res.ID, idColumnWidth), res.Summary)
+
+	if !withDetails {
+		return
+	}
+
+	for _, detail := range res.Details {
+		fmt.Fprintf(w, "      %s %s\n", padRight(detail.Key, detailKeyWidth), detail.Value)
+	}
+
+	if res.Remediation != "" {
+		fmt.Fprintf(w, "      %s %s\n", padRight("remediation", detailKeyWidth), res.Remediation)
+	}
+}
+
+// styledGlyph returns the status glyph styled with its status color
+func styledGlyph(s Status) string {
+	glyph := s.Glyph()
+
+	switch s {
+	case StatusOK:
+		return components.DoctorGlyphOKStyle.Render(glyph)
+	case StatusIdle:
+		return components.DoctorGlyphIdleStyle.Render(glyph)
+	case StatusNote:
+		return components.DoctorGlyphNoteStyle.Render(glyph)
+	case StatusWarn:
+		return components.DoctorGlyphWarnStyle.Render(glyph)
+	case StatusFail:
+		return components.DoctorGlyphFailStyle.Render(glyph)
+	default:
+		return glyph
+	}
+}
+
+// writeFooter prints the divider and the tally line
+func writeFooter(w io.Writer, r *Report) {
+	t := r.Tally()
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, divider)
+	fmt.Fprintf(w, "%d ok · %d idle · %d notes · %d warn · %d fail\n",
+		t.OK, t.Idle, t.Note, t.Warn, t.Fail)
+}
+
+// padRight returns s padded with spaces on the right to at least width runes
+func padRight(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+
+	return s + strings.Repeat(" ", width-len(s))
+}
+
+// jsonReport is the stable JSON schema for --json output
+type jsonReport struct {
+	SchemaVersion int                    `json:"schemaVersion"`
+	GeneratedAt   string                 `json:"generatedAt"`
+	FukuVersion   string                 `json:"fukuVersion"`
+	Platform      string                 `json:"platform"`
+	OverallStatus string                 `json:"overallStatus"`
+	Tally         jsonTally              `json:"tally"`
+	Checks        map[string]jsonCheck   `json:"checks"`
+	Sections      []jsonSectionReference `json:"sections"`
+}
+
+type jsonTally struct {
+	OK   int `json:"ok"`
+	Idle int `json:"idle"`
+	Note int `json:"note"`
+	Warn int `json:"warn"`
+	Fail int `json:"fail"`
+}
+
+type jsonCheck struct {
+	ID          string            `json:"id"`
+	Category    string            `json:"category"`
+	Status      string            `json:"status"`
+	Summary     string            `json:"summary"`
+	Details     map[string]string `json:"details,omitempty"`
+	Remediation string            `json:"remediation,omitempty"`
+	DurationMs  int64             `json:"durationMs"`
+}
+
+type jsonSectionReference struct {
+	Title  string   `json:"title"`
+	Note   string   `json:"note,omitempty"`
+	Checks []string `json:"checks"`
+}
+
+// toJSONReport converts a Report to the wire JSON representation
+func toJSONReport(r *Report) jsonReport {
+	out := jsonReport{
+		SchemaVersion: r.SchemaVersion,
+		GeneratedAt:   r.GeneratedAt.Format("2006-01-02T15:04:05Z"),
+		FukuVersion:   r.FukuVersion,
+		Platform:      r.Platform,
+		OverallStatus: r.OverallStatus().String(),
+		Tally:         jsonTally(r.Tally()),
+		Checks:        map[string]jsonCheck{},
+	}
+
+	for _, section := range r.Sections {
+		ref := jsonSectionReference{Title: section.Title, Note: section.Note}
+
+		for _, res := range section.Results {
+			out.Checks[res.ID] = jsonCheck{
+				ID:          res.ID,
+				Category:    res.Category,
+				Status:      res.Status.String(),
+				Summary:     res.Summary,
+				Details:     detailsToMap(res.Details),
+				Remediation: res.Remediation,
+				DurationMs:  res.DurationMs,
+			}
+			ref.Checks = append(ref.Checks, res.ID)
+		}
+
+		out.Sections = append(out.Sections, ref)
+	}
+
+	return out
+}
+
+// detailsToMap converts details to a string map, returning nil for empty input
+func detailsToMap(details []Detail) map[string]string {
+	if len(details) == 0 {
+		return nil
+	}
+
+	m := make(map[string]string, len(details))
+	for _, d := range details {
+		m[d.Key] = d.Value
+	}
+
+	return m
+}

--- a/internal/app/doctor/render_test.go
+++ b/internal/app/doctor/render_test.go
@@ -1,0 +1,298 @@
+package doctor
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_RenderText(t *testing.T) {
+	report := sampleReport()
+
+	var buf bytes.Buffer
+	RenderText(&buf, report)
+
+	out := buf.String()
+
+	tests := []struct {
+		name     string
+		contains string
+	}{
+		{
+			name:     "header includes version and platform",
+			contains: "fuku doctor v0.99.0 · linux-amd64",
+		},
+		{
+			name:     "notes header rendered when non-ok exists",
+			contains: "Notes",
+		},
+		{
+			name:     "non-ok results appear in notes block",
+			contains: "services.dotenv",
+		},
+		{
+			name:     "section title rendered",
+			contains: "Configuration",
+		},
+		{
+			name:     "section note appended with bullet separator",
+			contains: "Services · active profile: dev · 5 services",
+		},
+		{
+			name:     "ok glyph rendered",
+			contains: "✓",
+		},
+		{
+			name:     "warn glyph rendered",
+			contains: "⚠",
+		},
+		{
+			name:     "result details rendered",
+			contains: "path                      fuku.yaml",
+		},
+		{
+			name:     "remediation rendered",
+			contains: "remediation               create the missing .env files",
+		},
+		{
+			name:     "tally line rendered",
+			contains: "2 ok · 1 idle · 0 notes · 1 warn · 0 fail",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Contains(t, out, tt.contains)
+		})
+	}
+}
+
+func Test_RenderText_NoNotes(t *testing.T) {
+	report := &Report{
+		FukuVersion: "1.0.0",
+		Platform:    "linux-amd64",
+		Sections: []Section{
+			{Title: "Environment", Results: []Result{
+				{ID: "system", Status: StatusOK, Summary: "ok"},
+			}},
+		},
+	}
+
+	var buf bytes.Buffer
+	RenderText(&buf, report)
+
+	assert.NotContains(t, buf.String(), "Notes")
+}
+
+func Test_RenderSummary(t *testing.T) {
+	report := sampleReport()
+
+	var buf bytes.Buffer
+	RenderSummary(&buf, report)
+
+	out := buf.String()
+
+	tests := []struct {
+		name           string
+		contains       string
+		notContains    string
+		expectContains bool
+	}{
+		{
+			name:           "header rendered",
+			contains:       "fuku doctor v0.99.0",
+			expectContains: true,
+		},
+		{
+			name:           "result row rendered",
+			contains:       "config.file",
+			expectContains: true,
+		},
+		{
+			name:           "tally rendered",
+			contains:       "2 ok · 1 idle · 0 notes · 1 warn · 0 fail",
+			expectContains: true,
+		},
+		{
+			name:           "details suppressed",
+			contains:       "path                      fuku.yaml",
+			expectContains: false,
+		},
+		{
+			name:           "notes block suppressed",
+			contains:       "Notes\n",
+			expectContains: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.expectContains {
+				assert.Contains(t, out, tt.contains)
+				return
+			}
+
+			assert.NotContains(t, out, tt.contains)
+		})
+	}
+}
+
+func Test_RenderJSON(t *testing.T) {
+	report := sampleReport()
+
+	var buf bytes.Buffer
+	require.NoError(t, RenderJSON(&buf, report))
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+
+	assert.InDelta(t, float64(1), decoded["schemaVersion"], 0)
+	assert.Equal(t, "0.99.0", decoded["fukuVersion"])
+	assert.Equal(t, "linux-amd64", decoded["platform"])
+	assert.Equal(t, "warn", decoded["overallStatus"])
+	assert.Equal(t, "2026-06-06T12:00:00Z", decoded["generatedAt"])
+
+	tally, ok := decoded["tally"].(map[string]any)
+	require.True(t, ok)
+	assert.InDelta(t, float64(2), tally["ok"], 0)
+	assert.InDelta(t, float64(1), tally["warn"], 0)
+
+	checks, ok := decoded["checks"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, checks, "services.dotenv")
+	assert.Contains(t, checks, "config.file")
+	assert.Contains(t, checks, "runtime.sockets")
+}
+
+func Test_padRight(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		width    int
+		expected string
+	}{
+		{
+			name:     "shorter than width is padded",
+			input:    "abc",
+			width:    6,
+			expected: "abc   ",
+		},
+		{
+			name:     "exactly width is unchanged",
+			input:    "abcdef",
+			width:    6,
+			expected: "abcdef",
+		},
+		{
+			name:     "longer than width is unchanged",
+			input:    "abcdefgh",
+			width:    6,
+			expected: "abcdefgh",
+		},
+		{
+			name:     "empty string padded",
+			input:    "",
+			width:    3,
+			expected: "   ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, padRight(tt.input, tt.width))
+		})
+	}
+}
+
+func Test_styledGlyph(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   Status
+		contains string
+	}{
+		{
+			name:     "ok glyph wrapped with ansi color",
+			status:   StatusOK,
+			contains: "\x1b[",
+		},
+		{
+			name:     "fail glyph wrapped with ansi color",
+			status:   StatusFail,
+			contains: "\x1b[",
+		},
+		{
+			name:     "ok glyph rune still present under color",
+			status:   StatusOK,
+			contains: "✓",
+		},
+		{
+			name:     "unknown status falls back to plain glyph",
+			status:   Status(99),
+			contains: "?",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Contains(t, styledGlyph(tt.status), tt.contains)
+		})
+	}
+}
+
+func sampleReport() *Report {
+	return &Report{
+		SchemaVersion: 1,
+		GeneratedAt:   time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC),
+		FukuVersion:   "0.99.0",
+		Platform:      "linux-amd64",
+		Sections: []Section{
+			{
+				Title: "Configuration",
+				Results: []Result{
+					{
+						ID:       "config.file",
+						Category: "configuration",
+						Status:   StatusOK,
+						Summary:  "loaded",
+						Details:  []Detail{{Key: "path", Value: "fuku.yaml"}},
+					},
+				},
+			},
+			{
+				Title: "Services",
+				Note:  "active profile: dev · 5 services",
+				Results: []Result{
+					{
+						ID:          "services.dotenv",
+						Category:    "services",
+						Status:      StatusWarn,
+						Summary:     "1 of 4 referenced .env files missing",
+						Details:     []Detail{{Key: "auth/.env.local", Value: "MISSING"}},
+						Remediation: "create the missing .env files or update env.files",
+					},
+				},
+			},
+			{
+				Title: "Runtime",
+				Results: []Result{
+					{
+						ID:       "runtime.sockets",
+						Category: "runtime",
+						Status:   StatusOK,
+						Summary:  "no stale sockets",
+					},
+					{
+						ID:       "runtime.instance",
+						Category: "runtime",
+						Status:   StatusIdle,
+						Summary:  "no other fuku running",
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/app/doctor/runner.go
+++ b/internal/app/doctor/runner.go
@@ -1,0 +1,69 @@
+package doctor
+
+import (
+	"context"
+	"runtime"
+	"time"
+
+	"fuku/internal/config"
+)
+
+// Options controls a doctor run
+type Options struct {
+	Profile    string
+	ConfigPath string
+}
+
+// Env holds shared loaded state passed to each check
+type Env struct {
+	Profile         string
+	ConfigPath      string
+	ExplicitConfig  bool
+	OverridePath    string
+	Config          *config.Config
+	Topology        *config.Topology
+	LoadErr         error
+	ProfileServices []string
+	ProfileErr      error
+}
+
+// Run executes all doctor checks and returns the report
+func Run(ctx context.Context, opts Options) *Report {
+	env := loadEnv(opts)
+
+	report := &Report{
+		SchemaVersion: 1,
+		GeneratedAt:   time.Now().UTC(),
+		FukuVersion:   config.Version,
+		Platform:      runtime.GOOS + "-" + runtime.GOARCH,
+	}
+
+	report.Sections = []Section{
+		environmentSection(ctx, env),
+		configSection(ctx, env),
+		servicesSection(ctx, env),
+		topologySection(ctx, env),
+		runtimeSection(ctx, env),
+	}
+
+	return report
+}
+
+// loadEnv resolves config paths and attempts to load the config without panicking on failure
+func loadEnv(opts Options) *Env {
+	env := &Env{Profile: opts.Profile, ExplicitConfig: opts.ConfigPath != ""}
+
+	env.ConfigPath, _ = config.ResolveConfigPath(opts.ConfigPath)
+	env.OverridePath, _ = config.ResolveOverridePath(env.ConfigPath)
+
+	cfg, topo, err := config.LoadPath(opts.ConfigPath)
+	env.Config = cfg
+	env.Topology = topo
+	env.LoadErr = err
+
+	if cfg != nil && topo != nil {
+		env.ProfileServices, env.ProfileErr = resolveProfileServices(env)
+	}
+
+	return env
+}

--- a/internal/app/doctor/runner_test.go
+++ b/internal/app/doctor/runner_test.go
@@ -1,0 +1,83 @@
+package doctor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Run_NoConfig(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	report := Run(context.Background(), Options{Profile: "default"})
+
+	require.NotNil(t, report)
+	assert.Equal(t, 1, report.SchemaVersion)
+	assert.NotEmpty(t, report.FukuVersion)
+	assert.NotEmpty(t, report.Platform)
+	assert.Equal(t, 2, report.ExitCode())
+
+	configCheck := findCheck(t, report, "config.file")
+	assert.Equal(t, StatusFail, configCheck.Status)
+}
+
+func Test_Run_WithMinimalConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	serviceDir := filepath.Join(dir, "api")
+	require.NoError(t, os.MkdirAll(serviceDir, 0755))
+
+	configContent := `version: 1
+services:
+  api:
+    command: make run
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "fuku.yaml"), []byte(configContent), 0600))
+
+	report := Run(context.Background(), Options{Profile: "default"})
+
+	require.NotNil(t, report)
+	assert.Equal(t, 0, report.ExitCode())
+
+	tally := report.Tally()
+	assert.Positive(t, tally.OK)
+	assert.Equal(t, 0, tally.Fail)
+}
+
+func Test_Run_InvalidConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	configContent := `not: valid: yaml: at: all
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "fuku.yaml"), []byte(configContent), 0600))
+
+	report := Run(context.Background(), Options{Profile: "default"})
+
+	require.NotNil(t, report)
+	assert.Equal(t, 2, report.ExitCode())
+
+	configCheck := findCheck(t, report, "config.file")
+	assert.Equal(t, StatusFail, configCheck.Status)
+}
+
+func findCheck(t *testing.T, r *Report, id string) Result {
+	t.Helper()
+
+	for _, section := range r.Sections {
+		for _, res := range section.Results {
+			if res.ID == id {
+				return res
+			}
+		}
+	}
+
+	t.Fatalf("check %q not found", id)
+
+	return Result{}
+}

--- a/internal/app/doctor/runtime.go
+++ b/internal/app/doctor/runtime.go
@@ -1,0 +1,234 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"fuku/internal/app/relay"
+	"fuku/internal/config"
+)
+
+// runtimeSection collects runtime-state checks (sockets, instances, ports)
+func runtimeSection(ctx context.Context, env *Env) Section {
+	return Section{
+		Title: "Runtime",
+		Results: []Result{
+			timed(func() Result { return checkInstance(env) }),
+			timed(checkStaleSockets),
+			timed(func() Result { return checkPorts(ctx, env) }),
+		},
+	}
+}
+
+// checkInstance reports whether another fuku instance is running with the same profile
+func checkInstance(env *Env) Result {
+	socketPath := relay.SocketPathForProfile(config.SocketDir, env.Profile)
+
+	info, err := os.Lstat(socketPath)
+	if err != nil || info.Mode()&os.ModeSocket == 0 {
+		return Result{
+			ID:       "runtime.instance",
+			Category: "runtime",
+			Status:   StatusIdle,
+			Summary:  fmt.Sprintf("no other fuku running for profile '%s'", env.Profile),
+			Details:  []Detail{{Key: "socket", Value: socketPath + " (absent)"}},
+		}
+	}
+
+	conn, dialErr := net.DialTimeout("unix", socketPath, config.SocketDialTimeout)
+	if dialErr != nil {
+		return Result{
+			ID:          "runtime.instance",
+			Category:    "runtime",
+			Status:      StatusWarn,
+			Summary:     "socket present but unreachable",
+			Details:     []Detail{{Key: "socket", Value: socketPath}, {Key: "error", Value: dialErr.Error()}},
+			Remediation: "remove the stale socket: rm " + socketPath,
+		}
+	}
+
+	conn.Close()
+
+	return Result{
+		ID:       "runtime.instance",
+		Category: "runtime",
+		Status:   StatusNote,
+		Summary:  fmt.Sprintf("another fuku is running for profile '%s'", env.Profile),
+		Details:  []Detail{{Key: "socket", Value: socketPath}},
+	}
+}
+
+// checkStaleSockets reports stale socket files from previous fuku runs
+func checkStaleSockets() Result {
+	pattern := relay.SocketPathForProfile(config.SocketDir, "*")
+
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return Result{
+			ID:       "runtime.sockets",
+			Category: "runtime",
+			Status:   StatusWarn,
+			Summary:  "failed to glob socket directory",
+			Details:  []Detail{{Key: "error", Value: err.Error()}},
+		}
+	}
+
+	var stale []string
+
+	for _, socketPath := range matches {
+		info, err := os.Lstat(socketPath)
+		if err != nil || info.Mode()&os.ModeSocket == 0 {
+			continue
+		}
+
+		conn, err := net.DialTimeout("unix", socketPath, config.SocketDialTimeout)
+		if err == nil {
+			conn.Close()
+			continue
+		}
+
+		stale = append(stale, filepath.Base(socketPath))
+	}
+
+	if len(stale) == 0 {
+		return Result{
+			ID:       "runtime.sockets",
+			Category: "runtime",
+			Status:   StatusOK,
+			Summary:  "no stale sockets",
+			Details:  []Detail{{Key: "scanned", Value: fmt.Sprintf("%s (%d files)", pattern, len(matches))}},
+		}
+	}
+
+	details := make([]Detail, 0, len(stale))
+	for _, name := range stale {
+		details = append(details, Detail{Key: name, Value: "stale"})
+	}
+
+	return Result{
+		ID:          "runtime.sockets",
+		Category:    "runtime",
+		Status:      StatusWarn,
+		Summary:     fmt.Sprintf("%d stale socket file(s)", len(stale)),
+		Details:     details,
+		Remediation: "remove the stale sockets from " + config.SocketDir,
+	}
+}
+
+// checkPorts probes readiness ports for already-bound listeners
+func checkPorts(ctx context.Context, env *Env) Result {
+	if env.Config == nil {
+		return Result{
+			ID:       "runtime.ports",
+			Category: "runtime",
+			Status:   StatusIdle,
+			Summary:  "skipped (config did not load)",
+		}
+	}
+
+	if env.ProfileErr != nil {
+		return Result{
+			ID:       "runtime.ports",
+			Category: "runtime",
+			Status:   StatusIdle,
+			Summary:  "skipped (profile did not resolve)",
+		}
+	}
+
+	names := env.ProfileServices
+
+	var (
+		probed int
+		busy   []Detail
+	)
+
+	dialer := net.Dialer{Timeout: config.PreFlightTimeout}
+
+	for _, name := range names {
+		svc := env.Config.Services[name]
+		if svc.Readiness == nil {
+			continue
+		}
+
+		address := extractAddress(svc.Readiness)
+		if address == "" {
+			continue
+		}
+
+		probed++
+
+		conn, dialErr := dialer.DialContext(ctx, "tcp", address)
+		if dialErr != nil {
+			continue
+		}
+
+		conn.Close()
+
+		busy = append(busy, Detail{Key: name, Value: address + " already LISTENING"})
+	}
+
+	if probed == 0 {
+		return Result{
+			ID:       "runtime.ports",
+			Category: "runtime",
+			Status:   StatusIdle,
+			Summary:  "no probed readiness ports",
+		}
+	}
+
+	if len(busy) > 0 {
+		return Result{
+			ID:          "runtime.ports",
+			Category:    "runtime",
+			Status:      StatusWarn,
+			Summary:     fmt.Sprintf("%d readiness port(s) already bound", len(busy)),
+			Details:     busy,
+			Remediation: "stop the conflicting process or change the readiness port",
+		}
+	}
+
+	return Result{
+		ID:       "runtime.ports",
+		Category: "runtime",
+		Status:   StatusOK,
+		Summary:  fmt.Sprintf("%d readiness port(s) available", probed),
+	}
+}
+
+// portOrDefault returns the explicit URL port, falling back to scheme defaults (80/443)
+func portOrDefault(u *url.URL) string {
+	if port := u.Port(); port != "" {
+		return port
+	}
+
+	if u.Scheme == "https" {
+		return "443"
+	}
+
+	return "80"
+}
+
+// extractAddress derives host:port from a readiness probe configuration
+func extractAddress(r *config.Readiness) string {
+	switch r.Type {
+	case config.TypeTCP:
+		return r.Address
+	case config.TypeHTTP:
+		u, err := url.Parse(r.URL)
+		if err != nil || u.Host == "" {
+			return ""
+		}
+
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return ""
+		}
+
+		return net.JoinHostPort(u.Hostname(), portOrDefault(u))
+	default:
+		return ""
+	}
+}

--- a/internal/app/doctor/runtime_test.go
+++ b/internal/app/doctor/runtime_test.go
@@ -1,0 +1,110 @@
+package doctor
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fuku/internal/config"
+)
+
+func Test_extractAddress(t *testing.T) {
+	tests := []struct {
+		name     string
+		probe    *config.Readiness
+		expected string
+	}{
+		{
+			name:     "http with explicit port",
+			probe:    &config.Readiness{Type: config.TypeHTTP, URL: "http://localhost:8080/health"},
+			expected: "localhost:8080",
+		},
+		{
+			name:     "https default port",
+			probe:    &config.Readiness{Type: config.TypeHTTP, URL: "https://example.com/health"},
+			expected: "example.com:443",
+		},
+		{
+			name:     "http default port",
+			probe:    &config.Readiness{Type: config.TypeHTTP, URL: "http://example.com/health"},
+			expected: "example.com:80",
+		},
+		{
+			name:     "tcp address passthrough",
+			probe:    &config.Readiness{Type: config.TypeTCP, Address: "localhost:5432"},
+			expected: "localhost:5432",
+		},
+		{
+			name:     "log type returns empty",
+			probe:    &config.Readiness{Type: config.TypeLog, Pattern: "ready"},
+			expected: "",
+		},
+		{
+			name:     "malformed url returns empty",
+			probe:    &config.Readiness{Type: config.TypeHTTP, URL: "://broken"},
+			expected: "",
+		},
+		{
+			name:     "non-http scheme returns empty",
+			probe:    &config.Readiness{Type: config.TypeHTTP, URL: "ftp://host/health"},
+			expected: "",
+		},
+		{
+			name:     "scheme-less host returns empty",
+			probe:    &config.Readiness{Type: config.TypeHTTP, URL: "localhost:8080/health"},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, extractAddress(tt.probe))
+		})
+	}
+}
+
+func Test_checkInstance_NoSocket(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	env := &Env{Profile: "test-no-such-instance-" + filepath.Base(dir)}
+
+	r := checkInstance(env)
+
+	assert.Equal(t, StatusIdle, r.Status)
+}
+
+func Test_checkStaleSockets(t *testing.T) {
+	r := checkStaleSockets()
+
+	assert.Equal(t, "runtime.sockets", r.ID)
+	assert.Contains(t, []Status{StatusOK, StatusWarn}, r.Status)
+}
+
+func Test_checkPorts_NoConfig(t *testing.T) {
+	r := checkPorts(context.Background(), &Env{})
+
+	assert.Equal(t, StatusIdle, r.Status)
+}
+
+func Test_checkPorts_NoReadiness(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Services["api"] = &config.Service{Dir: "api"}
+
+	env := &Env{Config: cfg, Topology: config.DefaultTopology(), Profile: config.Default, ProfileServices: []string{"api"}}
+
+	r := checkPorts(context.Background(), env)
+
+	assert.Equal(t, StatusIdle, r.Status)
+}
+
+func Test_checkPorts_ProfileError(t *testing.T) {
+	env := &Env{Config: config.DefaultConfig(), Topology: config.DefaultTopology(), ProfileErr: assert.AnError}
+
+	r := checkPorts(context.Background(), env)
+
+	assert.Equal(t, StatusIdle, r.Status)
+	assert.Equal(t, "runtime.ports", r.ID)
+}

--- a/internal/app/doctor/services.go
+++ b/internal/app/doctor/services.go
@@ -1,0 +1,280 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+
+	"fuku/internal/app/discovery"
+	"fuku/internal/config"
+)
+
+// servicesSection collects per-service filesystem and field checks
+func servicesSection(_ context.Context, env *Env) Section {
+	section := Section{
+		Title: "Services",
+	}
+
+	if env.Config == nil {
+		section.Note = "skipped (config did not load)"
+		section.Results = skippedServiceResults("config did not load")
+
+		return section
+	}
+
+	// The profile resolution failure is reported authoritatively by topology.profile,
+	// so here we only skip the per-service checks that depend on it.
+	if env.ProfileErr != nil {
+		section.Note = "skipped (profile did not resolve)"
+		section.Results = skippedServiceResults("profile did not resolve")
+
+		return section
+	}
+
+	names := env.ProfileServices
+
+	section.Note = fmt.Sprintf("active profile: %s · %d services", env.Profile, len(names))
+	section.Results = []Result{
+		timed(func() Result { return checkServiceDirectories(env, names) }),
+		timed(func() Result { return checkServiceDotenv(env, names) }),
+		timed(func() Result { return checkServiceReadiness(env, names) }),
+	}
+
+	return section
+}
+
+// checkServiceDirectories verifies that each service.Dir exists on disk
+func checkServiceDirectories(env *Env, names []string) Result {
+	var missing []string
+
+	details := make([]Detail, 0, len(names))
+
+	for _, name := range names {
+		svc := env.Config.Services[name]
+		dir := serviceDirAbs(svc)
+
+		if dirExists(dir) {
+			details = append(details, Detail{Key: name, Value: dir})
+			continue
+		}
+
+		missing = append(missing, name)
+		details = append(details, Detail{Key: name, Value: dir + " (MISSING)"})
+	}
+
+	if len(missing) == 0 {
+		return Result{
+			ID:       "services.directories",
+			Category: "services",
+			Status:   StatusOK,
+			Summary:  fmt.Sprintf("%d of %d directories present", len(names), len(names)),
+			Details:  details,
+		}
+	}
+
+	return Result{
+		ID:          "services.directories",
+		Category:    "services",
+		Status:      StatusWarn,
+		Summary:     fmt.Sprintf("%d of %d directories missing", len(missing), len(names)),
+		Details:     details,
+		Remediation: "create the missing directories or fix `dir:` paths in fuku.yaml",
+	}
+}
+
+// checkServiceDotenv verifies that each referenced .env file exists and is readable
+func checkServiceDotenv(env *Env, names []string) Result {
+	var missing []string
+
+	total := 0
+	details := []Detail{}
+
+	for _, name := range names {
+		svc := env.Config.Services[name]
+		if svc.Env == nil || len(svc.Env.Files) == 0 {
+			continue
+		}
+
+		dir := serviceDirAbs(svc)
+
+		for _, file := range svc.Env.Files {
+			total++
+
+			path := filepath.Join(dir, file)
+			if fileExists(path) {
+				continue
+			}
+
+			label := fmt.Sprintf("%s/%s", name, file)
+			missing = append(missing, label)
+			details = append(details, Detail{Key: label, Value: "MISSING"})
+		}
+	}
+
+	if total == 0 {
+		return Result{
+			ID:       "services.dotenv",
+			Category: "services",
+			Status:   StatusIdle,
+			Summary:  "no .env files referenced",
+		}
+	}
+
+	if len(missing) == 0 {
+		return Result{
+			ID:       "services.dotenv",
+			Category: "services",
+			Status:   StatusOK,
+			Summary:  fmt.Sprintf("%d files referenced, all readable", total),
+		}
+	}
+
+	return Result{
+		ID:          "services.dotenv",
+		Category:    "services",
+		Status:      StatusWarn,
+		Summary:     fmt.Sprintf("%d of %d referenced .env files missing", len(missing), total),
+		Details:     details,
+		Remediation: "create the missing .env files or update `env.files` in fuku.yaml",
+	}
+}
+
+// checkServiceReadiness verifies probe fields parse as URL, regex, or host:port
+func checkServiceReadiness(env *Env, names []string) Result {
+	var (
+		http, tcp, log int
+		issues         []Detail
+	)
+
+	for _, name := range names {
+		svc := env.Config.Services[name]
+		if svc.Readiness == nil {
+			continue
+		}
+
+		r := svc.Readiness
+
+		switch r.Type {
+		case config.TypeHTTP:
+			http++
+
+			if err := validateHTTPURL(r.URL); err != nil {
+				issues = append(issues, Detail{Key: name + " url", Value: err.Error()})
+			}
+		case config.TypeTCP:
+			tcp++
+
+			if _, _, err := net.SplitHostPort(r.Address); err != nil {
+				issues = append(issues, Detail{Key: name + " address", Value: err.Error()})
+			}
+		case config.TypeLog:
+			log++
+
+			if _, err := regexp.Compile(r.Pattern); err != nil {
+				issues = append(issues, Detail{Key: name + " pattern", Value: err.Error()})
+			}
+		}
+	}
+
+	total := http + tcp + log
+	if total == 0 {
+		return Result{
+			ID:       "services.readiness",
+			Category: "services",
+			Status:   StatusIdle,
+			Summary:  "no readiness probes defined",
+		}
+	}
+
+	if len(issues) > 0 {
+		return Result{
+			ID:          "services.readiness",
+			Category:    "services",
+			Status:      StatusFail,
+			Summary:     fmt.Sprintf("%d probe field(s) failed to parse", len(issues)),
+			Details:     issues,
+			Remediation: "fix the malformed readiness fields in fuku.yaml",
+		}
+	}
+
+	return Result{
+		ID:       "services.readiness",
+		Category: "services",
+		Status:   StatusOK,
+		Summary:  fmt.Sprintf("%d probes parse (http=%d tcp=%d log=%d)", total, http, tcp, log),
+	}
+}
+
+// validateHTTPURL returns an error unless u parses as an absolute http(s) URL with a host
+func validateHTTPURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return err
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return errors.New("scheme must be http or https")
+	}
+
+	if u.Host == "" {
+		return errors.New("missing host")
+	}
+
+	return nil
+}
+
+// resolveProfileServices returns the sorted list of services in the active profile
+func resolveProfileServices(env *Env) ([]string, error) {
+	disc := discovery.NewDiscovery(env.Config, env.Topology)
+
+	tiers, err := disc.Resolve(env.Profile)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, tier := range tiers {
+		names = append(names, tier.Services...)
+	}
+
+	sort.Strings(names)
+
+	return names, nil
+}
+
+// serviceDirAbs returns the absolute service directory path
+func serviceDirAbs(svc *config.Service) string {
+	if filepath.IsAbs(svc.Dir) {
+		return svc.Dir
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return svc.Dir
+	}
+
+	return filepath.Join(cwd, svc.Dir)
+}
+
+// skippedServiceResults returns idle placeholders for the per-service checks with the given reason
+func skippedServiceResults(reason string) []Result {
+	ids := []string{"services.directories", "services.dotenv", "services.readiness"}
+	results := make([]Result, 0, len(ids))
+
+	for _, id := range ids {
+		results = append(results, Result{
+			ID:       id,
+			Category: "services",
+			Status:   StatusIdle,
+			Summary:  "skipped (" + reason + ")",
+		})
+	}
+
+	return results
+}

--- a/internal/app/doctor/services_test.go
+++ b/internal/app/doctor/services_test.go
@@ -1,0 +1,252 @@
+package doctor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"fuku/internal/config"
+)
+
+func Test_checkServiceDirectories(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "api"), 0755))
+
+	cfg := config.DefaultConfig()
+	cfg.Services["api"] = &config.Service{Dir: "api"}
+	cfg.Services["missing"] = &config.Service{Dir: "missing"}
+
+	env := &Env{Config: cfg}
+
+	tests := []struct {
+		name     string
+		names    []string
+		expected Status
+	}{
+		{
+			name:     "all present",
+			names:    []string{"api"},
+			expected: StatusOK,
+		},
+		{
+			name:     "some missing",
+			names:    []string{"api", "missing"},
+			expected: StatusWarn,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := checkServiceDirectories(env, tt.names)
+			assert.Equal(t, tt.expected, r.Status)
+		})
+	}
+}
+
+func Test_checkServiceDotenv(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	apiDir := filepath.Join(dir, "api")
+	require.NoError(t, os.MkdirAll(apiDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(apiDir, ".env"), []byte(""), 0600))
+
+	cfg := config.DefaultConfig()
+	cfg.Services["api"] = &config.Service{Dir: "api", Env: &config.Env{Files: []string{".env"}}}
+	cfg.Services["missing"] = &config.Service{Dir: "api", Env: &config.Env{Files: []string{".env.local"}}}
+	cfg.Services["noenv"] = &config.Service{Dir: "api"}
+
+	env := &Env{Config: cfg}
+
+	tests := []struct {
+		name     string
+		names    []string
+		expected Status
+	}{
+		{
+			name:     "no env files referenced",
+			names:    []string{"noenv"},
+			expected: StatusIdle,
+		},
+		{
+			name:     "all present",
+			names:    []string{"api"},
+			expected: StatusOK,
+		},
+		{
+			name:     "some missing",
+			names:    []string{"api", "missing"},
+			expected: StatusWarn,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := checkServiceDotenv(env, tt.names)
+			assert.Equal(t, tt.expected, r.Status)
+		})
+	}
+}
+
+func Test_checkServiceReadiness(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Services["http"] = &config.Service{
+		Readiness: &config.Readiness{Type: config.TypeHTTP, URL: "http://localhost:8080/health"},
+	}
+	cfg.Services["tcp"] = &config.Service{
+		Readiness: &config.Readiness{Type: config.TypeTCP, Address: "localhost:5432"},
+	}
+	cfg.Services["log"] = &config.Service{
+		Readiness: &config.Readiness{Type: config.TypeLog, Pattern: `ready\s+\d+`},
+	}
+	cfg.Services["badregex"] = &config.Service{
+		Readiness: &config.Readiness{Type: config.TypeLog, Pattern: `[invalid`},
+	}
+	cfg.Services["badaddr"] = &config.Service{
+		Readiness: &config.Readiness{Type: config.TypeTCP, Address: "no-port"},
+	}
+	cfg.Services["urlnoscheme"] = &config.Service{
+		Readiness: &config.Readiness{Type: config.TypeHTTP, URL: "localhost:8080/health"},
+	}
+	cfg.Services["urlnohost"] = &config.Service{
+		Readiness: &config.Readiness{Type: config.TypeHTTP, URL: "http:///health"},
+	}
+	cfg.Services["urlwrongscheme"] = &config.Service{
+		Readiness: &config.Readiness{Type: config.TypeHTTP, URL: "ftp://host/health"},
+	}
+	cfg.Services["none"] = &config.Service{}
+
+	env := &Env{Config: cfg}
+
+	tests := []struct {
+		name     string
+		names    []string
+		expected Status
+	}{
+		{
+			name:     "no probes",
+			names:    []string{"none"},
+			expected: StatusIdle,
+		},
+		{
+			name:     "all probes parse",
+			names:    []string{"http", "tcp", "log"},
+			expected: StatusOK,
+		},
+		{
+			name:     "bad regex",
+			names:    []string{"badregex"},
+			expected: StatusFail,
+		},
+		{
+			name:     "bad address",
+			names:    []string{"badaddr"},
+			expected: StatusFail,
+		},
+		{
+			name:     "http url without scheme is rejected",
+			names:    []string{"urlnoscheme"},
+			expected: StatusFail,
+		},
+		{
+			name:     "http url with empty host is rejected",
+			names:    []string{"urlnohost"},
+			expected: StatusFail,
+		},
+		{
+			name:     "http url with non-http scheme is rejected",
+			names:    []string{"urlwrongscheme"},
+			expected: StatusFail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := checkServiceReadiness(env, tt.names)
+			assert.Equal(t, tt.expected, r.Status)
+		})
+	}
+}
+
+func Test_validateHTTPURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "valid http", input: "http://localhost:8080/health", wantErr: false},
+		{name: "valid https", input: "https://example.com/health", wantErr: false},
+		{name: "missing scheme", input: "localhost:8080/health", wantErr: true},
+		{name: "empty host", input: "http:///health", wantErr: true},
+		{name: "wrong scheme", input: "ftp://host/health", wantErr: true},
+		{name: "parse error", input: "://broken", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHTTPURL(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func Test_servicesSection(t *testing.T) {
+	happyCfg := config.DefaultConfig()
+	happyCfg.Services["api"] = &config.Service{Dir: "api"}
+
+	tests := []struct {
+		name        string
+		env         *Env
+		wantNote    string
+		wantStatus  Status
+		wantResults int
+	}{
+		{
+			name:        "config did not load",
+			env:         &Env{},
+			wantNote:    "skipped (config did not load)",
+			wantStatus:  StatusIdle,
+			wantResults: 3,
+		},
+		{
+			name:        "profile did not resolve",
+			env:         &Env{Config: config.DefaultConfig(), ProfileErr: assert.AnError},
+			wantNote:    "skipped (profile did not resolve)",
+			wantStatus:  StatusIdle,
+			wantResults: 3,
+		},
+		{
+			name:        "resolves to services",
+			env:         &Env{Config: happyCfg, Profile: config.Default, ProfileServices: []string{"api"}},
+			wantNote:    "active profile: default · 1 services",
+			wantResults: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			section := servicesSection(context.Background(), tt.env)
+
+			assert.Equal(t, "Services", section.Title)
+			assert.Equal(t, tt.wantNote, section.Note)
+			require.Len(t, section.Results, tt.wantResults)
+
+			if tt.wantStatus != StatusOK {
+				for _, r := range section.Results {
+					assert.Equal(t, tt.wantStatus, r.Status)
+				}
+			}
+		})
+	}
+}

--- a/internal/app/doctor/topology.go
+++ b/internal/app/doctor/topology.go
@@ -1,0 +1,94 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// topologySection collects tier and profile topology checks
+func topologySection(_ context.Context, env *Env) Section {
+	if env.Config == nil || env.Topology == nil {
+		return Section{
+			Title: "Topology",
+			Results: []Result{
+				{
+					ID:       "topology.tiers",
+					Category: "topology",
+					Status:   StatusIdle,
+					Summary:  "skipped (config did not load)",
+				},
+			},
+		}
+	}
+
+	return Section{
+		Title: "Topology",
+		Results: []Result{
+			timed(func() Result { return checkTiers(env) }),
+			timed(func() Result { return checkProfileResolves(env) }),
+		},
+	}
+}
+
+// checkTiers reports the resolved tier execution order
+func checkTiers(env *Env) Result {
+	topo := env.Topology
+
+	if topo.HasDefaultOnly {
+		return Result{
+			ID:       "topology.tiers",
+			Category: "topology",
+			Status:   StatusIdle,
+			Summary:  "no tiers defined (default tier only)",
+		}
+	}
+
+	details := make([]Detail, 0, len(topo.Order))
+	for _, tier := range topo.Order {
+		details = append(details, Detail{
+			Key:   tier,
+			Value: fmt.Sprintf("%d services", len(topo.TierServices[tier])),
+		})
+	}
+
+	return Result{
+		ID:       "topology.tiers",
+		Category: "topology",
+		Status:   StatusOK,
+		Summary:  strings.Join(topo.Order, " → "),
+		Details:  details,
+	}
+}
+
+// checkProfileResolves reports whether the active profile resolves to a non-empty service list
+func checkProfileResolves(env *Env) Result {
+	if env.ProfileErr != nil {
+		return Result{
+			ID:          "topology.profile",
+			Category:    "topology",
+			Status:      StatusFail,
+			Summary:     fmt.Sprintf("profile '%s' does not resolve", env.Profile),
+			Details:     []Detail{{Key: "error", Value: env.ProfileErr.Error()}},
+			Remediation: "check that the profile is defined and references existing services",
+		}
+	}
+
+	names := env.ProfileServices
+
+	if len(names) == 0 {
+		return Result{
+			ID:       "topology.profile",
+			Category: "topology",
+			Status:   StatusWarn,
+			Summary:  fmt.Sprintf("profile '%s' resolves to 0 services", env.Profile),
+		}
+	}
+
+	return Result{
+		ID:       "topology.profile",
+		Category: "topology",
+		Status:   StatusOK,
+		Summary:  fmt.Sprintf("profile '%s' resolves to %d services", env.Profile, len(names)),
+	}
+}

--- a/internal/app/doctor/topology_test.go
+++ b/internal/app/doctor/topology_test.go
@@ -1,0 +1,70 @@
+package doctor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"fuku/internal/config"
+)
+
+func Test_checkTiers(t *testing.T) {
+	tests := []struct {
+		name     string
+		topology *config.Topology
+		expected Status
+	}{
+		{
+			name:     "default tier only",
+			topology: &config.Topology{HasDefaultOnly: true},
+			expected: StatusIdle,
+		},
+		{
+			name: "multiple tiers",
+			topology: &config.Topology{
+				Order:        []string{"backend", "frontend"},
+				TierServices: map[string][]string{"backend": {"api"}, "frontend": {"web"}},
+			},
+			expected: StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := &Env{Config: config.DefaultConfig(), Topology: tt.topology}
+			r := checkTiers(env)
+			assert.Equal(t, tt.expected, r.Status)
+		})
+	}
+}
+
+func Test_checkProfileResolves(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      *Env
+		expected Status
+	}{
+		{
+			name:     "profile resolves to services",
+			env:      &Env{Profile: config.Default, ProfileServices: []string{"api"}},
+			expected: StatusOK,
+		},
+		{
+			name:     "profile resolves to zero services",
+			env:      &Env{Profile: config.Default, ProfileServices: nil},
+			expected: StatusWarn,
+		},
+		{
+			name:     "profile does not resolve",
+			env:      &Env{Profile: "nonexistent", ProfileErr: assert.AnError},
+			expected: StatusFail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := checkProfileResolves(tt.env)
+			assert.Equal(t, tt.expected, r.Status)
+		})
+	}
+}

--- a/internal/app/ui/components/styles.go
+++ b/internal/app/ui/components/styles.go
@@ -35,3 +35,12 @@ var (
 	SpinnerStyle      = lipgloss.NewStyle().Foreground(FgPrimary)
 	LoaderSpacerStyle = lipgloss.NewStyle().PaddingLeft(1)
 )
+
+// Doctor glyph styles
+var (
+	DoctorGlyphOKStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
+	DoctorGlyphIdleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	DoctorGlyphNoteStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("14"))
+	DoctorGlyphWarnStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
+	DoctorGlyphFailStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+)

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -55,7 +55,7 @@ func LoadFromFile(path string) (*Config, *Topology, error) {
 	return parseConfig(cfg, data)
 }
 
-// LoadEnv loads environment variables from .env files in priority order.
+// LoadEnv loads environment variables from .env files in priority order
 // Files loaded first take precedence (godotenv does not override existing vars):
 //
 //	.env.<GO_ENV>.local  (highest priority)

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -1,0 +1,28 @@
+package config
+
+// LoadPath loads configuration from path, or from the default config file when path is empty
+func LoadPath(path string) (*Config, *Topology, error) {
+	if path != "" {
+		return LoadFromFile(path)
+	}
+
+	return Load()
+}
+
+// ResolveConfigPath returns explicit when set, otherwise the first existing default config file
+func ResolveConfigPath(explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+
+	return resolveDefaultConfig()
+}
+
+// ResolveOverridePath returns the override file beside basePath, or empty when basePath is empty or no override exists
+func ResolveOverridePath(basePath string) (string, error) {
+	if basePath == "" {
+		return "", nil
+	}
+
+	return resolveOverrideFile(basePath)
+}

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_LoadPath(t *testing.T) {
+	t.Run("default config when path empty", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+
+		cfg, topo, err := LoadPath("")
+
+		require.NoError(t, err)
+		assert.NotNil(t, cfg)
+		assert.NotNil(t, topo)
+	})
+
+	t.Run("explicit path is loaded", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "custom.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("version: 1"), 0600))
+
+		cfg, topo, err := LoadPath(path)
+
+		require.NoError(t, err)
+		assert.NotNil(t, cfg)
+		assert.NotNil(t, topo)
+	})
+
+	t.Run("explicit path not found returns error", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+
+		_, _, err := LoadPath("nonexistent.yaml")
+
+		require.Error(t, err)
+	})
+}
+
+func Test_ResolveConfigPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		explicit string
+		setup    func(t *testing.T) string
+		expected string
+	}{
+		{
+			name:     "explicit path returned as-is",
+			explicit: "custom.yaml",
+			setup:    func(t *testing.T) string { return t.TempDir() },
+			expected: "custom.yaml",
+		},
+		{
+			name: "default fuku.yaml found",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "fuku.yaml"), []byte("version: 1"), 0600))
+
+				return dir
+			},
+			expected: "fuku.yaml",
+		},
+		{
+			name: "alt fuku.yml found when fuku.yaml absent",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "fuku.yml"), []byte("version: 1"), 0600))
+
+				return dir
+			},
+			expected: "fuku.yml",
+		},
+		{
+			name:     "no config returns empty",
+			setup:    func(t *testing.T) string { return t.TempDir() },
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(tt.setup(t))
+
+			path, err := ResolveConfigPath(tt.explicit)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, path)
+		})
+	}
+}
+
+func Test_ResolveOverridePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		basePath string
+		setup    func(t *testing.T) string
+		expected string
+	}{
+		{
+			name:     "empty base returns empty",
+			basePath: "",
+			setup:    func(t *testing.T) string { return t.TempDir() },
+			expected: "",
+		},
+		{
+			name:     "override yaml found",
+			basePath: "fuku.yaml",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "fuku.override.yaml"), []byte(""), 0600))
+
+				return dir
+			},
+			expected: "fuku.override.yaml",
+		},
+		{
+			name:     "override yml found when yaml absent",
+			basePath: "fuku.yaml",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "fuku.override.yml"), []byte(""), 0600))
+
+				return dir
+			},
+			expected: "fuku.override.yml",
+		},
+		{
+			name:     "no override returns empty",
+			basePath: "fuku.yaml",
+			setup:    func(t *testing.T) string { return t.TempDir() },
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(tt.setup(t))
+
+			path, err := ResolveOverridePath(tt.basePath)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, path)
+		})
+	}
+}


### PR DESCRIPTION
- Check configuration, environment, services, topology, and runtime without starting services
- Support `--summary` and `--json` output, with exit codes 0/2/3 for scripting and CI
- Extract `config.LoadPath`, deduping the cmd config-loading wrapper