### PR TITLE
fix(ui): Add pending status

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -487,7 +487,10 @@ The UI uses finite state machines to manage visual representation of service sta
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Stopped
+    [*] --> Pending
+
+    Pending --> Starting : Start
+    Pending --> Failed : Failed
 
     Stopped --> Starting : Start
 
@@ -515,6 +518,7 @@ stateDiagram-v2
 type Status string
 
 const (
+    StatusPending    Status = "pending"    // Queued for startup, process not spawned yet
     StatusStarting   Status = "starting"   // Process started, waiting for readiness
     StatusRunning    Status = "running"    // Service ready and operational
     StatusStopping   Status = "stopping"   // Shutdown in progress

--- a/docs/src/pages/docs/api.astro
+++ b/docs/src/pages/docs/api.astro
@@ -16,6 +16,7 @@ const statusJson = esc(`{
   "uptime": 3600,
   "services": {
     "total": 8,
+    "pending": 0,
     "starting": 0,
     "running": 6,
     "stopping": 0,

--- a/e2e/concurrency_test.go
+++ b/e2e/concurrency_test.go
@@ -1,0 +1,114 @@
+package e2e
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	concurrencyAPIBase  = "http://127.0.0.1:19877"
+	concurrencyAPIToken = "test-token"
+)
+
+// statusSample holds one observation of the status endpoint during startup
+type statusSample struct {
+	phase  string
+	counts map[string]int
+}
+
+// fetchStatusSample polls the status endpoint, returning false while the API is not reachable yet
+func fetchStatusSample() (statusSample, bool) {
+	req, err := http.NewRequest(http.MethodGet, concurrencyAPIBase+"/api/v1/status", nil)
+	if err != nil {
+		return statusSample{}, false
+	}
+
+	req.Header.Set("Authorization", "Bearer "+concurrencyAPIToken)
+
+	client := &http.Client{Timeout: time.Second}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return statusSample{}, false
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return statusSample{}, false
+	}
+
+	var parsed struct {
+		Phase    string         `json:"phase"`
+		Services map[string]int `json:"services"`
+	}
+
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return statusSample{}, false
+	}
+
+	return statusSample{phase: parsed.Phase, counts: parsed.Services}, true
+}
+
+func Test_Concurrency_WorkersSerializeStartup(t *testing.T) {
+	runner := NewRunner(t, "testdata/concurrency")
+	defer runner.Stop()
+
+	err := runner.Start("default")
+	require.NoError(t, err)
+
+	// Sample the status endpoint during startup: with workers: 1 the queue
+	// must drain one service at a time while the rest report pending
+	var (
+		maxStarting int
+		sawQueue    bool
+	)
+
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	timeout := time.After(30 * time.Second)
+
+sampling:
+	for {
+		select {
+		case <-timeout:
+			break sampling
+		case <-ticker.C:
+			sample, ok := fetchStatusSample()
+			if !ok {
+				continue
+			}
+
+			maxStarting = max(maxStarting, sample.counts["starting"])
+
+			if sample.counts["starting"] == 1 && sample.counts["pending"] >= 1 {
+				sawQueue = true
+			}
+
+			if sample.phase == "running" {
+				break sampling
+			}
+		}
+	}
+
+	err = runner.WaitForRunning(30 * time.Second)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, maxStarting, 1, "workers: 1 must never start more than one service at a time")
+	require.True(t, sawQueue, "expected to observe one starting service while others were pending\nOutput:\n%s", runner.Output())
+
+	sample, ok := fetchStatusSample()
+	require.True(t, ok)
+	assert.Equal(t, "running", sample.phase)
+	assert.Equal(t, 3, sample.counts["total"])
+	assert.Equal(t, 3, sample.counts["running"])
+	assert.Equal(t, 0, sample.counts["pending"])
+	assert.Equal(t, 0, sample.counts["starting"])
+}

--- a/e2e/testdata/concurrency/fuku.yaml
+++ b/e2e/testdata/concurrency/fuku.yaml
@@ -1,0 +1,39 @@
+version: 1
+
+services:
+  alpha:
+    dir: .
+    command: "echo starting; sleep 2; echo 'Service ready'; sleep 60"
+    readiness:
+      type: log
+      pattern: "Service ready"
+      timeout: 30s
+  bravo:
+    dir: .
+    command: "echo starting; sleep 2; echo 'Service ready'; sleep 60"
+    readiness:
+      type: log
+      pattern: "Service ready"
+      timeout: 30s
+  charlie:
+    dir: .
+    command: "echo starting; sleep 2; echo 'Service ready'; sleep 60"
+    readiness:
+      type: log
+      pattern: "Service ready"
+      timeout: 30s
+
+profiles:
+  default: "*"
+
+concurrency:
+  workers: 1
+
+server:
+  listen: "127.0.0.1:19877"
+  auth:
+    token: "test-token"
+
+logging:
+  format: console
+  level: debug

--- a/internal/app/api/handler.go
+++ b/internal/app/api/handler.go
@@ -28,6 +28,7 @@ type StatusSerializer struct {
 // ServiceCountSerializer serializes service counts by status
 type ServiceCountSerializer struct {
 	Total      int `json:"total"`
+	Pending    int `json:"pending"`
 	Starting   int `json:"starting"`
 	Running    int `json:"running"`
 	Stopping   int `json:"stopping"`
@@ -113,6 +114,7 @@ func (h *handler) handleStatus(w http.ResponseWriter, _ *http.Request) {
 		Uptime:  int64(h.store.Uptime().Seconds()),
 		Services: ServiceCountSerializer{
 			Total:      c.Total,
+			Pending:    c.Pending,
 			Starting:   c.Starting,
 			Running:    c.Running,
 			Stopping:   c.Stopping,

--- a/internal/app/registry/store.go
+++ b/internal/app/registry/store.go
@@ -17,6 +17,7 @@ type Status string
 
 // Status values for service lifecycle
 const (
+	StatusPending    Status = "pending"
 	StatusStarting   Status = "starting"
 	StatusRunning    Status = "running"
 	StatusStopping   Status = "stopping"
@@ -67,6 +68,7 @@ type ServiceSnapshot struct {
 // StatusCounts contains service counts grouped by status
 type StatusCounts struct {
 	Total      int
+	Pending    int
 	Starting   int
 	Running    int
 	Stopping   int
@@ -263,6 +265,8 @@ func (s *store) transitionStatus(svc *serviceState, newStatus Status) {
 
 func (s *store) incrementCount(status Status) {
 	switch status {
+	case StatusPending:
+		s.counts.Pending++
 	case StatusStarting:
 		s.counts.Starting++
 	case StatusRunning:
@@ -280,6 +284,8 @@ func (s *store) incrementCount(status Status) {
 
 func (s *store) decrementCount(status Status) {
 	switch status {
+	case StatusPending:
+		s.counts.Pending--
 	case StatusStarting:
 		s.counts.Starting--
 	case StatusRunning:
@@ -531,7 +537,7 @@ func (s *store) initServices(tiers []bus.Tier) {
 
 	s.services = make(map[string]*serviceState, totalServices)
 	s.serviceOrder = nil
-	s.counts = StatusCounts{Total: totalServices, Starting: totalServices}
+	s.counts = StatusCounts{Total: totalServices, Pending: totalServices}
 
 	tierIndex := make(map[string]int, len(tiers))
 	for i, tier := range tiers {
@@ -553,7 +559,7 @@ func (s *store) initServices(tiers []bus.Tier) {
 				id:     svc.ID,
 				name:   svc.Name,
 				tier:   tier.Name,
-				status: StatusStarting,
+				status: StatusPending,
 			}
 			entries = append(entries, serviceEntry{
 				id:        svc.ID,

--- a/internal/app/registry/store_test.go
+++ b/internal/app/registry/store_test.go
@@ -847,3 +847,37 @@ func Test_Store_StaleLifecycleEventRejected(t *testing.T) {
 	assert.Equal(t, 1234, svc.PID)
 	assert.Equal(t, startedAt, svc.StartTime)
 }
+
+func Test_Store_CountBookkeeping(t *testing.T) {
+	s := &store{}
+
+	statuses := []Status{
+		StatusPending,
+		StatusStarting,
+		StatusRunning,
+		StatusStopping,
+		StatusRestarting,
+		StatusStopped,
+		StatusFailed,
+	}
+
+	for _, status := range statuses {
+		s.incrementCount(status)
+	}
+
+	assert.Equal(t, StatusCounts{
+		Pending:    1,
+		Starting:   1,
+		Running:    1,
+		Stopping:   1,
+		Restarting: 1,
+		Stopped:    1,
+		Failed:     1,
+	}, s.counts)
+
+	for _, status := range statuses {
+		s.decrementCount(status)
+	}
+
+	assert.Equal(t, StatusCounts{}, s.counts)
+}

--- a/internal/app/registry/store_test.go
+++ b/internal/app/registry/store_test.go
@@ -65,7 +65,7 @@ func Test_Store_ProfileResolved(t *testing.T) {
 	assert.Equal(t, "web", services[3].Name)
 
 	for _, svc := range services {
-		assert.Equal(t, StatusStarting, svc.Status)
+		assert.Equal(t, StatusPending, svc.Status)
 		assert.NotEmpty(t, svc.ID)
 	}
 }
@@ -335,6 +335,11 @@ func Test_Status_IsStartable(t *testing.T) {
 			status: StatusRestarting,
 			want:   false,
 		},
+		{
+			name:   "pending",
+			status: StatusPending,
+			want:   false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -368,6 +373,11 @@ func Test_Status_IsStoppable(t *testing.T) {
 		{
 			name:   "failed",
 			status: StatusFailed,
+			want:   false,
+		},
+		{
+			name:   "pending",
+			status: StatusPending,
 			want:   false,
 		},
 	}
@@ -415,6 +425,11 @@ func Test_Status_IsRestartable(t *testing.T) {
 			status: StatusRestarting,
 			want:   false,
 		},
+		{
+			name:   "pending",
+			status: StatusPending,
+			want:   false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -444,7 +459,8 @@ func Test_Store_Counts(t *testing.T) {
 
 	counts := s.Counts()
 	assert.Equal(t, 2, counts.Total)
-	assert.Equal(t, 2, counts.Starting)
+	assert.Equal(t, 2, counts.Pending)
+	assert.Equal(t, 0, counts.Starting)
 	assert.Equal(t, 0, counts.Running)
 
 	b.Publish(bus.Message{
@@ -458,7 +474,7 @@ func Test_Store_Counts(t *testing.T) {
 
 	counts = s.Counts()
 	assert.Equal(t, 2, counts.Total)
-	assert.Equal(t, 1, counts.Starting)
+	assert.Equal(t, 1, counts.Pending)
 	assert.Equal(t, 1, counts.Running)
 
 	b.Publish(bus.Message{
@@ -472,7 +488,7 @@ func Test_Store_Counts(t *testing.T) {
 
 	counts = s.Counts()
 	assert.Equal(t, 2, counts.Total)
-	assert.Equal(t, 0, counts.Starting)
+	assert.Equal(t, 0, counts.Pending)
 	assert.Equal(t, 1, counts.Running)
 	assert.Equal(t, 1, counts.Failed)
 

--- a/internal/app/ui/components/theme.go
+++ b/internal/app/ui/components/theme.go
@@ -29,6 +29,7 @@ type Theme struct {
 	ServiceHeaderStyle   lipgloss.Style
 	SelectedRowStyle     lipgloss.Style
 	SelectionBgStyle     lipgloss.Style
+	StatusPendingStyle   lipgloss.Style
 	StatusRunningStyle   lipgloss.Style
 	StatusStartingStyle  lipgloss.Style
 	StatusFailedStyle    lipgloss.Style
@@ -103,6 +104,7 @@ func NewTheme(isDark bool) Theme {
 		ServiceHeaderStyle:   lipgloss.NewStyle().Foreground(fgMuted).Padding(0, 2),
 		SelectedRowStyle:     lipgloss.NewStyle().Background(bgSelection).Padding(0, 2),
 		SelectionBgStyle:     lipgloss.NewStyle().Background(bgSelection),
+		StatusPendingStyle:   lipgloss.NewStyle().Foreground(fgMuted),
 		StatusRunningStyle:   lipgloss.NewStyle().Foreground(fgStatusRunning),
 		StatusStartingStyle:  lipgloss.NewStyle().Foreground(fgStatusWarning),
 		StatusFailedStyle:    lipgloss.NewStyle().Foreground(fgStatusError),

--- a/internal/app/ui/services/aside.go
+++ b/internal/app/ui/services/aside.go
@@ -519,6 +519,8 @@ func (m Model) lookupServiceConfig(name string) *config.Service {
 // asideStatusStyle returns the style used for the status badge
 func (m Model) asideStatusStyle(status Status) lipgloss.Style {
 	switch status {
+	case StatusPending:
+		return m.theme.StatusPendingStyle
 	case StatusRunning:
 		return m.theme.StatusRunningStyle
 	case StatusStarting, StatusRestarting, StatusStopping:

--- a/internal/app/ui/services/aside_test.go
+++ b/internal/app/ui/services/aside_test.go
@@ -1006,3 +1006,60 @@ func Test_AsideTabIndex(t *testing.T) {
 		})
 	}
 }
+
+func Test_AsideStatusStyle(t *testing.T) {
+	m := Model{theme: components.DefaultTheme()}
+
+	tests := []struct {
+		name   string
+		status Status
+		want   lipgloss.Style
+	}{
+		{
+			name:   "pending uses pending style",
+			status: StatusPending,
+			want:   m.theme.StatusPendingStyle,
+		},
+		{
+			name:   "running uses running style",
+			status: StatusRunning,
+			want:   m.theme.StatusRunningStyle,
+		},
+		{
+			name:   "starting uses starting style",
+			status: StatusStarting,
+			want:   m.theme.StatusStartingStyle,
+		},
+		{
+			name:   "restarting uses starting style",
+			status: StatusRestarting,
+			want:   m.theme.StatusStartingStyle,
+		},
+		{
+			name:   "stopping uses starting style",
+			status: StatusStopping,
+			want:   m.theme.StatusStartingStyle,
+		},
+		{
+			name:   "failed uses failed style",
+			status: StatusFailed,
+			want:   m.theme.StatusFailedStyle,
+		},
+		{
+			name:   "stopped uses stopped style",
+			status: StatusStopped,
+			want:   m.theme.StatusStoppedStyle,
+		},
+		{
+			name:   "unknown uses muted style",
+			status: Status("bogus"),
+			want:   m.theme.PanelMutedStyle,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, m.asideStatusStyle(tt.status))
+		})
+	}
+}

--- a/internal/app/ui/services/model.go
+++ b/internal/app/ui/services/model.go
@@ -34,6 +34,7 @@ type Status = registry.Status
 
 // Status values re-exported from registry for convenience
 const (
+	StatusPending    = registry.StatusPending
 	StatusStarting   = registry.StatusStarting
 	StatusRunning    = registry.StatusRunning
 	StatusStopping   = registry.StatusStopping

--- a/internal/app/ui/services/monitor_test.go
+++ b/internal/app/ui/services/monitor_test.go
@@ -383,6 +383,18 @@ func Test_UpdateBlinkAnimations(t *testing.T) {
 			expectedHasActive:  true,
 			expectBlinkStarted: map[string]bool{"api": true},
 		},
+		{
+			name: "pending service does not blink",
+			services: map[string]*ServiceState{
+				"api": {
+					Name:   "api",
+					Status: StatusPending,
+					Blink:  components.NewBlink(),
+				},
+			},
+			expectedHasActive:  false,
+			expectBlinkStarted: map[string]bool{"api": false},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/app/ui/services/timeline_test.go
+++ b/internal/app/ui/services/timeline_test.go
@@ -183,6 +183,11 @@ func Test_StatusToSlot(t *testing.T) {
 			want:   SlotStopped,
 		},
 		{
+			name:   "pending maps to SlotEmpty",
+			status: StatusPending,
+			want:   SlotEmpty,
+		},
+		{
 			name:   "unknown status maps to SlotEmpty",
 			status: "unknown",
 			want:   SlotEmpty,

--- a/internal/app/ui/services/update.go
+++ b/internal/app/ui/services/update.go
@@ -620,7 +620,7 @@ func (m Model) handleProfileResolved(msg bus.Message) Model {
 				ID:       ref.ID,
 				Name:     ref.Name,
 				Tier:     tier.Name,
-				Status:   StatusStarting,
+				Status:   StatusPending,
 				Blink:    components.NewBlink(),
 				Timeline: NewTimeline(components.TimelineDefaultSlots),
 			}

--- a/internal/app/ui/services/update_test.go
+++ b/internal/app/ui/services/update_test.go
@@ -60,7 +60,7 @@ func Test_HandleProfileResolved(t *testing.T) {
 	assert.NotNil(t, result.state.services["test-id-db"])
 	assert.NotNil(t, result.state.services["test-id-api"])
 	assert.NotNil(t, result.state.services["test-id-web"])
-	assert.Equal(t, StatusStarting, result.state.services["test-id-db"].Status)
+	assert.Equal(t, StatusPending, result.state.services["test-id-db"].Status)
 	assert.NotNil(t, result.state.services["test-id-db"].Blink)
 	assert.NotNil(t, result.state.services["test-id-api"].Blink)
 	assert.NotNil(t, result.state.services["test-id-web"].Blink)

--- a/internal/app/ui/services/view.go
+++ b/internal/app/ui/services/view.go
@@ -603,6 +603,8 @@ func (m Model) styledStatus(service *ServiceState, isSelected bool) string {
 	}
 
 	switch service.Status {
+	case StatusPending:
+		return m.theme.StatusPendingStyle.Render(statusStr)
 	case StatusRunning:
 		return m.theme.StatusRunningStyle.Render(statusStr)
 	case StatusStarting:

--- a/internal/app/ui/services/view_test.go
+++ b/internal/app/ui/services/view_test.go
@@ -160,6 +160,11 @@ func Test_GetStyledAndPaddedStatus(t *testing.T) {
 			isSelected: false,
 		},
 		{
+			name:       "pending status not selected",
+			status:     StatusPending,
+			isSelected: false,
+		},
+		{
 			name:       "running status selected",
 			status:     StatusRunning,
 			isSelected: true,

--- a/plugins/jetbrains/src/main/kotlin/com/fuku/plugin/api/Models.kt
+++ b/plugins/jetbrains/src/main/kotlin/com/fuku/plugin/api/Models.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 enum class ServiceStatus {
+  pending,
   starting,
   running,
   stopping,
@@ -59,6 +60,7 @@ data class ServiceActionAccepted(
 @Serializable
 data class ServiceCounts(
   val total: Int,
+  val pending: Int = 0,
   val starting: Int,
   val running: Int,
   val stopping: Int,

--- a/plugins/jetbrains/src/main/kotlin/com/fuku/plugin/toolwindow/ServiceTable.kt
+++ b/plugins/jetbrains/src/main/kotlin/com/fuku/plugin/toolwindow/ServiceTable.kt
@@ -29,6 +29,7 @@ object ServiceColors {
 
   fun forStatus(status: ServiceStatus): Color =
     when (status) {
+      ServiceStatus.pending -> muted
       ServiceStatus.running -> running
       ServiceStatus.starting, ServiceStatus.restarting -> warning
       ServiceStatus.stopping -> error

--- a/plugins/jetbrains/src/main/kotlin/com/fuku/plugin/toolwindow/ServiceTableModel.kt
+++ b/plugins/jetbrains/src/main/kotlin/com/fuku/plugin/toolwindow/ServiceTableModel.kt
@@ -21,6 +21,7 @@ enum class TimelineSlot {
   companion object {
     fun forStatus(status: ServiceStatus): TimelineSlot =
       when (status) {
+        ServiceStatus.pending -> EMPTY
         ServiceStatus.running -> RUNNING
         ServiceStatus.starting, ServiceStatus.restarting, ServiceStatus.stopping -> STARTING
         ServiceStatus.failed -> FAILED

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -23,7 +23,7 @@ components:
   schemas:
     ServiceStatus:
       type: string
-      enum: [starting, running, stopping, restarting, stopped, failed]
+      enum: [pending, starting, running, stopping, restarting, stopped, failed]
       description: Current service state
       example: running
 
@@ -114,11 +114,14 @@ components:
 
     ServiceCounts:
       type: object
-      required: [total, starting, running, stopping, restarting, stopped, failed]
+      required: [total, pending, starting, running, stopping, restarting, stopped, failed]
       properties:
         total:
           type: integer
           example: 8
+        pending:
+          type: integer
+          example: 0
         starting:
           type: integer
           example: 0


### PR DESCRIPTION
- Initialize services as pending at profile resolution instead of starting
- Transition to starting only when the runner spawns the process, so the blink animation reflect actual startup activity