### PR TITLE
refactor(app): Deduplicate string literals into constants

### DIFF
--- a/internal/app/api/handler.go
+++ b/internal/app/api/handler.go
@@ -56,6 +56,13 @@ type ServiceListSerializer struct {
 	Services []ServiceSerializer `json:"services"`
 }
 
+// Action values reported in accepted action responses
+const (
+	actionStart   = "start"
+	actionStop    = "stop"
+	actionRestart = "restart"
+)
+
 // ActionSerializer serializes an accepted action response
 type ActionSerializer struct {
 	ID     string          `json:"id"`
@@ -209,7 +216,7 @@ func (h *handler) handleStartService(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(ActionSerializer{
 		ID:     svc.ID,
 		Name:   svc.Name,
-		Action: "start",
+		Action: actionStart,
 		Status: registry.StatusStarting,
 	})
 }
@@ -262,7 +269,7 @@ func (h *handler) handleStopService(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(ActionSerializer{
 		ID:     svc.ID,
 		Name:   svc.Name,
-		Action: "stop",
+		Action: actionStop,
 		Status: registry.StatusStopping,
 	})
 }
@@ -315,7 +322,7 @@ func (h *handler) handleRestartService(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(ActionSerializer{
 		ID:     svc.ID,
 		Name:   svc.Name,
-		Action: "restart",
+		Action: actionRestart,
 		Status: registry.StatusRestarting,
 	})
 }

--- a/internal/app/cli/commands.go
+++ b/internal/app/cli/commands.go
@@ -8,17 +8,17 @@ import (
 )
 
 // CommandType represents the type of CLI command
-type CommandType int
+type CommandType string
 
 // Command type values
 const (
-	CommandRun CommandType = iota
-	CommandStop
-	CommandInit
-	CommandLogs
-	CommandVersion
-	CommandHelp
-	CommandDoctor
+	CommandRun     CommandType = "run"
+	CommandStop    CommandType = "stop"
+	CommandInit    CommandType = "init"
+	CommandLogs    CommandType = "logs"
+	CommandVersion CommandType = "version"
+	CommandHelp    CommandType = "help"
+	CommandDoctor  CommandType = "doctor"
 )
 
 // Standalone returns true for commands that run without config or FX container
@@ -43,24 +43,7 @@ func (c CommandType) RequiresServices() bool {
 
 // String returns the string representation of a CommandType
 func (c CommandType) String() string {
-	switch c {
-	case CommandRun:
-		return "run"
-	case CommandStop:
-		return "stop"
-	case CommandInit:
-		return "init"
-	case CommandLogs:
-		return "logs"
-	case CommandVersion:
-		return "version"
-	case CommandHelp:
-		return "help"
-	case CommandDoctor:
-		return "doctor"
-	default:
-		return "unknown"
-	}
+	return string(c)
 }
 
 // DoctorFormat selects the doctor renderer
@@ -151,7 +134,7 @@ func Parse(args []string) (*Options, error) {
 // buildRootCommand creates the root cobra command
 func buildRootCommand(result *Options, flags *rootFlags) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "fuku",
+		Use:           config.AppName,
 		Short:         "A lightweight CLI orchestrator for running and managing multiple local services",
 		Long:          "Fuku is a lightweight CLI orchestrator for running and managing multiple local services in development environments",
 		SilenceUsage:  true,
@@ -163,11 +146,11 @@ func buildRootCommand(result *Options, flags *rootFlags) *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&result.NoUI, "no-ui", false, "Run without TUI")
 	cmd.PersistentFlags().StringVarP(&result.ConfigFile, "config", "c", "", "Path to config file (disables override merging)")
-	cmd.Flags().BoolVarP(&flags.version, "version", "v", false, "Show version information")
-	cmd.Flags().StringVarP(&flags.run, "run", "r", "", "Run services with specified profile")
-	cmd.Flags().StringVarP(&flags.stop, "stop", "s", "", "Stop services with specified profile")
-	cmd.Flags().BoolVarP(&flags.logs, "logs", "l", false, "Stream logs from running services")
-	cmd.Flags().BoolVarP(&flags.init, "init", "i", false, "Generate fuku.yaml template")
+	cmd.Flags().BoolVarP(&flags.version, CommandVersion.String(), "v", false, "Show version information")
+	cmd.Flags().StringVarP(&flags.run, CommandRun.String(), "r", "", "Run services with specified profile")
+	cmd.Flags().StringVarP(&flags.stop, CommandStop.String(), "s", "", "Stop services with specified profile")
+	cmd.Flags().BoolVarP(&flags.logs, CommandLogs.String(), "l", false, "Stream logs from running services")
+	cmd.Flags().BoolVarP(&flags.init, CommandInit.String(), "i", false, "Generate fuku.yaml template")
 
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		result.Type = CommandHelp
@@ -179,7 +162,7 @@ func buildRootCommand(result *Options, flags *rootFlags) *cobra.Command {
 // buildInitCommand creates the init subcommand
 func buildInitCommand(result *Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "init",
+		Use:     CommandInit.String(),
 		Aliases: []string{"i"},
 		Short:   "Generate fuku.yaml template",
 		Args:    cobra.NoArgs,
@@ -194,7 +177,7 @@ func buildInitCommand(result *Options) *cobra.Command {
 // buildRunCommand creates the run subcommand
 func buildRunCommand(result *Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "run [profile]",
+		Use:     CommandRun.String() + " [profile]",
 		Aliases: []string{"r"},
 		Short:   "Run services with the specified profile",
 		Args:    cobra.MaximumNArgs(1),
@@ -212,7 +195,7 @@ func buildRunCommand(result *Options) *cobra.Command {
 // buildStopCommand creates the stop subcommand
 func buildStopCommand(result *Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "stop [profile]",
+		Use:     CommandStop.String() + " [profile]",
 		Aliases: []string{"s"},
 		Short:   "Stop services by killing processes in service directories",
 		Args:    cobra.MaximumNArgs(1),
@@ -232,7 +215,7 @@ func buildLogsCommand(result *Options) *cobra.Command {
 	var logsProfile string
 
 	cmd := &cobra.Command{
-		Use:     "logs [services...]",
+		Use:     CommandLogs.String() + " [services...]",
 		Aliases: []string{"l"},
 		Short:   "Stream logs from running services",
 		Run: func(cmd *cobra.Command, args []string) {
@@ -250,7 +233,7 @@ func buildLogsCommand(result *Options) *cobra.Command {
 // buildVersionCommand creates the version subcommand
 func buildVersionCommand(result *Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "version",
+		Use:   CommandVersion.String(),
 		Short: "Show version information",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -269,7 +252,7 @@ func buildDoctorCommand(result *Options) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "doctor [profile]",
+		Use:   CommandDoctor.String() + " [profile]",
 		Short: "Diagnose configuration, environment, and runtime issues",
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/app/doctor/environment.go
+++ b/internal/app/doctor/environment.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+
+	"fuku/internal/config"
 )
 
 // environmentSection collects environment and toolchain checks
@@ -68,7 +70,7 @@ func checkInstall() Result {
 		{Key: "executable", Value: exe},
 	}
 
-	if pathExe, err := exec.LookPath("fuku"); err == nil {
+	if pathExe, err := exec.LookPath(config.AppName); err == nil {
 		details = append(details, Detail{Key: "PATH fuku", Value: pathExe})
 	}
 

--- a/internal/app/tracer/tracer.go
+++ b/internal/app/tracer/tracer.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"fuku/internal/app/bus"
+	"fuku/internal/app/cli"
 	"fuku/internal/config"
 	"fuku/internal/config/sentry"
 )
@@ -74,7 +75,7 @@ func (t *tracer) handleCommandStarted(ctx context.Context, msg bus.Message) {
 		return
 	}
 
-	if data.Command != "run" {
+	if data.Command != cli.CommandRun.String() {
 		return
 	}
 

--- a/internal/app/ui/components/blink.go
+++ b/internal/app/ui/components/blink.go
@@ -10,7 +10,7 @@ import (
 // Blink animation constants
 const (
 	empty = "◯"
-	full  = "◉"
+	full  = IndicatorDot
 
 	// Animation timing derived from UI tick rate
 	blinkFPS = UITicksPerSecond

--- a/internal/app/ui/services/view.go
+++ b/internal/app/ui/services/view.go
@@ -130,10 +130,8 @@ func (m Model) renderStatus() string {
 		phaseStr = "starting…"
 		phaseStyle = m.theme.PhaseStartingStyle
 	case bus.PhaseRunning:
-		phaseStr = "running"
 		phaseStyle = m.theme.PhaseRunningStyle
 	case bus.PhaseStopping:
-		phaseStr = "stopping"
 		phaseStyle = m.theme.PhaseStoppingStyle
 	}
 

--- a/internal/config/sentry/identity.go
+++ b/internal/config/sentry/identity.go
@@ -6,10 +6,12 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+
+	"fuku/internal/config"
 )
 
 const (
-	configDir       = "fuku"
+	configDir       = config.AppName
 	telemetryIDFile = "telemetry.id"
 )
 


### PR DESCRIPTION
- Convert CommandType from an int enum to string constants
- Reference the command-name constants in the cobra flag and Use definitions
- Extract the API action names into actionStart, actionStop and actionRestart constants
- Reuse config.AppName for the root command
- Reuse IndicatorDot for the blink full frame